### PR TITLE
[All] Updating packages to latest

### DIFF
--- a/alpaca-scheduler/front-end/shared-compose/build.gradle.kts
+++ b/alpaca-scheduler/front-end/shared-compose/build.gradle.kts
@@ -31,3 +31,7 @@ android {
     sourceSets["main"].res.srcDirs("src/androidMain/res")
     sourceSets["main"].resources.srcDirs("src/commonMain/resources")
 }
+
+compose.resources {
+    packageOfResClass = "shared_compose"
+}

--- a/alpaca-scheduler/front-end/shared-compose/src/commonMain/kotlin/App.kt
+++ b/alpaca-scheduler/front-end/shared-compose/src/commonMain/kotlin/App.kt
@@ -13,11 +13,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import coreproject.alpaca_scheduler.front_end.`shared-compose`.generated.resources.Res
-import coreproject.alpaca_scheduler.front_end.`shared-compose`.generated.resources.compose_multiplatform
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import shared_compose.Res
+import shared_compose.compose_multiplatform
 
 @OptIn(ExperimentalResourceApi::class)
 @Composable

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx4096M
+org.gradle.jvmargs=-Xmx8G
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,9 +1,9 @@
 pluginManagement {
     repositories {
-        maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
         google()
         mavenCentral()
         gradlePluginPortal()
+        maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     }
 }
 

--- a/versions.properties
+++ b/versions.properties
@@ -9,26 +9,25 @@
 ####
 #### NOTE: Some versions are filtered by the rejectVersionIf predicate. See the settings.gradle.kts file.
 
-plugin.com.google.devtools.ksp=1.9.22-1.0.18
-##                 # available=1.9.23-1.0.19
+plugin.com.google.devtools.ksp=1.9.23-1.0.20
 
 plugin.io.ktor.plugin=2.3.9
 
 plugin.io.gitlab.arturbosch.detekt=1.23.5
 
-version.androidx.compose=2024.02.02
+version.androidx.compose=2024.04.00
 
 version.androidx.compose.material3=1.2.1
 
-plugin.org.jetbrains.compose=1.6.0
+plugin.org.jetbrains.compose=1.6.10-dev1575
 
 plugin.com.squareup.sqldelight=1.5.5
 
-plugin.com.google.dagger.hilt.android=2.51
+plugin.com.google.dagger.hilt.android=2.51.1
 
 plugin.androidx.navigation.safeargs.kotlin=2.7.7
 
-version.com.google.cloud..google-cloud-translate=2.37.0
+version.com.google.cloud..google-cloud-translate=2.41.0
 
 version.androidx.core=1.12.0
 
@@ -45,7 +44,7 @@ version.io.insert-koin..koin-compose=1.0.4
 
 version.dev.kord..kord-core=0.13.1
 
-version.com.github.twitch4j..twitch4j=1.19.0
+version.com.github.twitch4j..twitch4j=1.20.0
 
 ## unused
 version.org.jetbrains.compose.material3..material3=1.5.3
@@ -59,6 +58,9 @@ version.org.jetbrains.compose.animation..animation=1.5.3
 version.org.ehcache..ehcache=3.10.8
 
  version.koin=3.5.3
+### available=3.5.4
+### available=3.5.5
+### available=3.5.6
 
 ## unused
 version.koin-core=3.5.3
@@ -96,31 +98,29 @@ version.org.apache.logging.log4j..log4j-slf4j-impl=2.23.1
 
 version.org.apache.logging.log4j..log4j-slf4j2-impl=2.23.1
 
-version.org.jetbrains.compose.ui..ui-tooling-preview=1.6.0
+version.org.jetbrains.compose.ui..ui-tooling-preview=1.6.2
 
-version.software.amazon.awssdk..cloudwatch=2.25.7
+version.software.amazon.awssdk..cloudwatch=2.25.31
 
-version.software.amazon.awssdk..auth=2.25.7
+version.software.amazon.awssdk..auth=2.25.31
 
-version.software.amazon.awscdk..aws-cdk-lib=2.132.0
+version.software.amazon.awscdk..aws-cdk-lib=2.137.0
 
-version.robolectric=4.11.1
+version.robolectric=4.12.1
 
 version.org.apache.logging.log4j..log4j-core=2.23.1
 
 version.org.apache.logging.log4j..log4j-api=2.23.1
 
-version.mockk=1.13.9
-### available=1.13.10
+version.mockk=1.13.10
 
- version.ktor=2.3.9
+ version.ktor=2.3.10
 
 version.kotlinx.serialization=1.6.3
 
 version.kotlinx.coroutines=1.8.0
 
-version.kotlin=1.9.22
-## # available=1.9.23
+version.kotlin=1.9.23
 
 version.junit.jupiter=5.10.2
 
@@ -129,51 +129,73 @@ version.junit.junit=4.13.2
 ## unused
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.22.0
 
+## unused
 version.io.github.libktx..ktx-vis-style=1.10.0-b4
 
+## unused
 version.io.github.libktx..ktx-vis=1.10.0-b4
 
+## unused
 version.io.github.libktx..ktx-tiled=1.10.0-b4
 
+## unused
 version.io.github.libktx..ktx-style=1.10.0-b4
 
+## unused
 version.io.github.libktx..ktx-scene2d=1.10.0-b4
 
+## unused
 version.io.github.libktx..ktx-preferences=1.10.0-b4
 
+## unused
 version.io.github.libktx..ktx-math=1.10.0-b4
 
+## unused
 version.io.github.libktx..ktx-log=1.10.0-b4
 
+## unused
 version.io.github.libktx..ktx-json=1.10.0-b4
 
+## unused
 version.io.github.libktx..ktx-inject=1.10.0-b4
 
+## unused
 version.io.github.libktx..ktx-i18n=1.10.0-b4
 
+## unused
 version.io.github.libktx..ktx-graphics=1.10.0-b4
 
+## unused
 version.io.github.libktx..ktx-freetype-async=1.10.0-b4
 
+## unused
 version.io.github.libktx..ktx-freetype=1.10.0-b4
 
+## unused
 version.io.github.libktx..ktx-collections=1.10.0-b4
 
+## unused
 version.io.github.libktx..ktx-box2d=1.10.0-b4
 
+## unused
 version.io.github.libktx..ktx-async=1.10.0-b4
 
+## unused
 version.io.github.libktx..ktx-assets-async=1.10.0-b4
 
+## unused
 version.io.github.libktx..ktx-assets=1.10.0-b4
 
+## unused
 version.io.github.libktx..ktx-ashley=1.10.0-b4
 
+## unused
 version.io.github.libktx..ktx-app=1.10.0-b4
 
+## unused
 version.io.github.libktx..ktx-actors=1.10.0-b4
 
-version.google.dagger=2.51
+version.google.dagger=2.51.1
 
 version.google.android.material=1.11.0
 
@@ -181,6 +203,7 @@ version.com.microsoft.appcenter..appcenter-crashes=5.0.4
 
 version.com.microsoft.appcenter..appcenter-analytics=5.0.4
 
+## unused
 version.com.badlogicgames.gdx..gdx=1.12.1
 
 version.com.android.support..support-compat=28.0.0
@@ -201,9 +224,9 @@ version.androidx.hilt=1.2.0
 
 version.androidx.fragment=1.6.2
 
-version.androidx.compose.ui=1.6.3
+version.androidx.compose.ui=1.6.5
 
-version.androidx.compose.foundation=1.6.3
+version.androidx.compose.foundation=1.6.5
 
 ## unused
 version.androidx.compose.compiler=1.5.3


### PR DESCRIPTION
This is a pass at upgrading our packages. The only non-standard package is the Compose plugin, which was upgraded to `1.6.10-dev1575`. This is due to needing to access the Compose resources API in gradle to change the generated resources package name.

Other minor improvements include:
- Increasing jvm memory to 8G
- Changed the priority of some repositories

Pwease review!