### PR TITLE
[EDIFIKANA] Adding initial Account screen

### DIFF
--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/core/controller/auth/SupabaseContextRetriever.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/core/controller/auth/SupabaseContextRetriever.kt
@@ -28,6 +28,7 @@ class SupabaseContextRetriever(
         }
 
         val user = auth.retrieveUser(token)
+        assertNull(auth.currentUserOrNull(), TAG, "Library cannot sign in user")
 
         return ClientContext.AuthenticatedClientContext(
             userInfo = user,

--- a/edifikana/front-end/shared-compose/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/di/koin/ViewModelDependencies.kt
+++ b/edifikana/front-end/shared-compose/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/di/koin/ViewModelDependencies.kt
@@ -1,6 +1,8 @@
 package com.cramsan.edifikana.client.lib.di.koin
 
 import com.cramsan.edifikana.client.lib.features.root.EdifikanaApplicationViewModel
+import com.cramsan.edifikana.client.lib.features.root.account.AccountActivityViewModel
+import com.cramsan.edifikana.client.lib.features.root.account.account.AccountViewModel
 import com.cramsan.edifikana.client.lib.features.root.auth.AuthActivityViewModel
 import com.cramsan.edifikana.client.lib.features.root.auth.signinv2.SignInV2ViewModel
 import com.cramsan.edifikana.client.lib.features.root.auth.signup.SignUpViewModel
@@ -30,5 +32,7 @@ val ViewModelModule = module {
     singleOf(::SignInV2ViewModel)
     singleOf(::SignUpViewModel)
     singleOf(::AuthActivityViewModel)
+    singleOf(::AccountActivityViewModel)
+    singleOf(::AccountViewModel)
     singleOf(::EdifikanaApplicationViewModel)
 }

--- a/edifikana/front-end/shared-compose/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/root/ApplicationRoute.kt
+++ b/edifikana/front-end/shared-compose/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/root/ApplicationRoute.kt
@@ -12,12 +12,18 @@ enum class ApplicationRoute(
 ) {
     Main("home"),
     Splash("splash"),
-    Auth("account"),
+    Auth("auth"),
+    Account("account"),
     ;
 }
 
 /**
- * Destinations in the application.
+ * Destinations in the application. The [route] is the [ApplicationRoute] of the destination to navigate to.
+ * The [path] is the path to the destination with any placeholders already resolved.
+ *
+ * For example if the [route] is an enum with a string "user/{id}", the path would be something like "user/123".
+ * In this case, the route would be "user/{id}"(as registered in the router) and the path would be "user/123",  where
+ * the value of {id} would be 123.
  */
 sealed class ActivityRouteDestination(
     val route: ApplicationRoute,
@@ -46,5 +52,13 @@ sealed class ActivityRouteDestination(
     data object AuthDestination : ActivityRouteDestination(
         ApplicationRoute.Auth,
         ApplicationRoute.Auth.route,
+    )
+
+    /**
+     * A class representing navigating to the account page.
+     */
+    data object AccountDestination : ActivityRouteDestination(
+        ApplicationRoute.Account,
+        ApplicationRoute.Account.route,
     )
 }

--- a/edifikana/front-end/shared-compose/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/root/EdifikanaApplicationScreen.kt
+++ b/edifikana/front-end/shared-compose/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/root/EdifikanaApplicationScreen.kt
@@ -10,6 +10,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import com.cramsan.edifikana.client.lib.features.root.account.AccountActivityScreen
 import com.cramsan.edifikana.client.lib.features.root.auth.AuthActivityScreen
 import com.cramsan.edifikana.client.lib.features.root.main.MainActivityScreen
 import com.cramsan.edifikana.client.lib.features.root.splash.SplashActivityScreen
@@ -84,6 +85,9 @@ private fun ApplicationNavigationHost(
                 }
                 ApplicationRoute.Main -> composable(route.route) {
                     MainActivityScreen()
+                }
+                ApplicationRoute.Account -> composable(route.route) {
+                    AccountActivityScreen()
                 }
             }
         }

--- a/edifikana/front-end/shared-compose/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/root/account/AccountActivityEvent.kt
+++ b/edifikana/front-end/shared-compose/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/root/account/AccountActivityEvent.kt
@@ -1,0 +1,22 @@
+package com.cramsan.edifikana.client.lib.features.root.account
+
+import kotlin.random.Random
+
+/**
+ * Events that can be triggered in the account activity.
+ */
+sealed class AccountActivityEvent {
+
+    /**
+     * No operation.
+     */
+    data object Noop : AccountActivityEvent()
+
+    /**
+     * Navigate to a destination within this activity.
+     */
+    data class Navigate(
+        val destination: AccountActivityRoute,
+        val id: Int = Random.nextInt(),
+    ) : AccountActivityEvent()
+}

--- a/edifikana/front-end/shared-compose/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/root/account/AccountActivityRoute.kt
+++ b/edifikana/front-end/shared-compose/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/root/account/AccountActivityRoute.kt
@@ -1,0 +1,33 @@
+@file:Suppress("TooManyFunctions")
+@file:OptIn(RouteSafePath::class)
+
+package com.cramsan.edifikana.client.lib.features.root.account
+
+import com.cramsan.edifikana.client.lib.features.root.RouteSafePath
+
+/**
+ * Routes in the account activity.
+ */
+enum class AccountActivityRoute(
+    @RouteSafePath
+    val route: String,
+) {
+    Account(route = "signin"),
+    ;
+}
+
+/**
+ * Destinations in the account activity.
+ */
+sealed class AccountRouteDestination(
+    @RouteSafePath
+    val path: String,
+) {
+
+    /**
+     * A class representing navigating to the account screen within the account activity.
+     */
+    data object AccountDestination : AccountRouteDestination(
+        AccountActivityRoute.Account.route,
+    )
+}

--- a/edifikana/front-end/shared-compose/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/root/account/AccountActivityScreen.kt
+++ b/edifikana/front-end/shared-compose/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/root/account/AccountActivityScreen.kt
@@ -1,0 +1,81 @@
+package com.cramsan.edifikana.client.lib.features.root.account
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.cramsan.edifikana.client.lib.features.root.RouteSafePath
+import com.cramsan.edifikana.client.lib.features.root.account.account.AccountScreen
+import com.cramsan.edifikana.client.lib.ui.components.EdifikanaTopBar
+import org.koin.compose.koinInject
+
+/**
+ * Account activity screen. It is an activity as it manages internal navigation.
+ */
+@OptIn(RouteSafePath::class)
+@Composable
+fun AccountActivityScreen(
+    viewModel: AccountActivityViewModel = koinInject()
+) {
+    val navController = rememberNavController()
+    val backStack by navController.currentBackStack.collectAsState()
+
+    val viewModelEvent by viewModel.event.collectAsState(AccountActivityEvent.Noop)
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+    }
+
+    LaunchedEffect(viewModelEvent) {
+        when (val event = viewModelEvent) {
+            AccountActivityEvent.Noop -> Unit
+            is AccountActivityEvent.Navigate -> {
+                navController.navigate(event.destination.route)
+            }
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            EdifikanaTopBar(
+                title = "",
+                showUpArrow = (backStack.size > 2),
+                onUpArrowClicked = { navController.navigateUp() },
+                onAccountClicked = null,
+            )
+        },
+    ) { innerPadding ->
+        NavigationHost(
+            navController = navController,
+            modifier = Modifier.padding(innerPadding),
+        )
+    }
+}
+
+@OptIn(RouteSafePath::class)
+@Composable
+private fun NavigationHost(
+    navController: NavHostController,
+    modifier: Modifier = Modifier,
+) {
+    NavHost(
+        navController,
+        startDestination = AccountActivityRoute.Account.route,
+        modifier = modifier,
+    ) {
+        AccountActivityRoute.entries.forEach {
+            when (it) {
+                AccountActivityRoute.Account -> composable(it.route) {
+                    AccountScreen()
+                }
+            }
+        }
+    }
+}

--- a/edifikana/front-end/shared-compose/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/root/account/AccountActivityViewModel.kt
+++ b/edifikana/front-end/shared-compose/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/root/account/AccountActivityViewModel.kt
@@ -1,0 +1,31 @@
+package com.cramsan.edifikana.client.lib.features.root.account
+
+import com.cramsan.edifikana.client.lib.features.base.EdifikanaBaseViewModel
+import com.cramsan.framework.core.DispatcherProvider
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Account activity view model.
+ */
+class AccountActivityViewModel(
+    exceptionHandler: CoroutineExceptionHandler,
+    dispatcherProvider: DispatcherProvider,
+) : EdifikanaBaseViewModel(exceptionHandler, dispatcherProvider) {
+
+    private val _event = MutableSharedFlow<AccountActivityEvent>()
+
+    /**
+     * Event flow to be observed.
+     */
+    val event: SharedFlow<AccountActivityEvent> = _event
+
+    /**
+     * Execute an event.
+     */
+    fun executeEvent(event: AccountActivityEvent) = viewModelScope.launch {
+        _event.emit(event)
+    }
+}

--- a/edifikana/front-end/shared-compose/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/root/account/account/AccountEvent.kt
+++ b/edifikana/front-end/shared-compose/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/root/account/account/AccountEvent.kt
@@ -1,0 +1,32 @@
+package com.cramsan.edifikana.client.lib.features.root.account.account
+
+import com.cramsan.edifikana.client.lib.features.root.EdifikanaApplicationEvent
+import com.cramsan.edifikana.client.lib.features.root.account.AccountActivityEvent
+import kotlin.random.Random
+
+/**
+ * Events that can be triggered in the account.
+ */
+sealed class AccountEvent {
+
+    /**
+     * No operation.
+     */
+    data object Noop : AccountEvent()
+
+    /**
+     * Trigger application event.
+     */
+    data class TriggerEdifikanaApplicationEvent(
+        val edifikanaApplicationEvent: EdifikanaApplicationEvent,
+        val id: Int = Random.nextInt(),
+    ) : AccountEvent()
+
+    /**
+     * Trigger activity event.
+     */
+    data class TriggerAccountActivityEvent(
+        val accountActivityEvent: AccountActivityEvent,
+        val id: Int = Random.nextInt(),
+    ) : AccountEvent()
+}

--- a/edifikana/front-end/shared-compose/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/root/account/account/AccountScreen.kt
+++ b/edifikana/front-end/shared-compose/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/root/account/account/AccountScreen.kt
@@ -1,0 +1,56 @@
+package com.cramsan.edifikana.client.lib.features.root.account.account
+
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
+import com.cramsan.edifikana.client.lib.features.root.EdifikanaApplicationViewModel
+import com.cramsan.edifikana.client.lib.features.root.account.AccountActivityViewModel
+import org.koin.compose.koinInject
+
+/**
+ * Account screen.
+ */
+@Composable
+fun AccountScreen(
+    viewModel: AccountViewModel = koinInject(),
+    accountActivityViewModel: AccountActivityViewModel = koinInject(),
+    applicationViewModel: EdifikanaApplicationViewModel = koinInject(),
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val viewModelEvent by viewModel.event.collectAsState(AccountEvent.Noop)
+
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+    }
+
+    LaunchedEffect(viewModelEvent) {
+        when (val event = viewModelEvent) {
+            AccountEvent.Noop -> Unit
+            is AccountEvent.TriggerEdifikanaApplicationEvent -> {
+                applicationViewModel.executeEvent(event.edifikanaApplicationEvent)
+            }
+            is AccountEvent.TriggerAccountActivityEvent -> {
+                accountActivityViewModel.executeEvent(event.accountActivityEvent)
+            }
+        }
+    }
+
+    AccountContent(
+        uiState.content,
+    ) {
+        viewModel.signOut()
+    }
+}
+
+@Composable
+internal fun AccountContent(content: AccountUIModel, onSignOutClicked: () -> Unit) {
+    // This is a placeholder. The actual content will be more complex.
+    Text("Account Screen: ${content.name}")
+    Button(onSignOutClicked) {
+        Text("Sign Out")
+    }
+}

--- a/edifikana/front-end/shared-compose/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/root/account/account/AccountUIModel.kt
+++ b/edifikana/front-end/shared-compose/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/root/account/account/AccountUIModel.kt
@@ -1,0 +1,9 @@
+package com.cramsan.edifikana.client.lib.features.root.account.account
+
+/**
+ * Account UI model.
+ */
+data class AccountUIModel(
+    // This is a placeholder model.
+    val name: String,
+)

--- a/edifikana/front-end/shared-compose/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/root/account/account/AccountUIState.kt
+++ b/edifikana/front-end/shared-compose/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/root/account/account/AccountUIState.kt
@@ -1,0 +1,9 @@
+package com.cramsan.edifikana.client.lib.features.root.account.account
+
+/**
+ * Account UI state of the screen.
+ */
+data class AccountUIState(
+    val content: AccountUIModel,
+    val isLoading: Boolean,
+)

--- a/edifikana/front-end/shared-compose/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/root/account/account/AccountViewModel.kt
+++ b/edifikana/front-end/shared-compose/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/root/account/account/AccountViewModel.kt
@@ -1,0 +1,56 @@
+package com.cramsan.edifikana.client.lib.features.root.account.account
+
+import com.cramsan.edifikana.client.lib.features.base.EdifikanaBaseViewModel
+import com.cramsan.edifikana.client.lib.features.root.ActivityRouteDestination
+import com.cramsan.edifikana.client.lib.features.root.EdifikanaApplicationEvent
+import com.cramsan.edifikana.client.lib.managers.AuthManager
+import com.cramsan.framework.core.DispatcherProvider
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * Account screen view model.
+ */
+class AccountViewModel(
+    private val auth: AuthManager,
+    exceptionHandler: CoroutineExceptionHandler,
+    dispatcherProvider: DispatcherProvider,
+) : EdifikanaBaseViewModel(exceptionHandler, dispatcherProvider) {
+
+    private val _uiState = MutableStateFlow(
+        AccountUIState(
+            content = AccountUIModel(""),
+            isLoading = false,
+        )
+    )
+
+    /**
+     * UI state of the screen.
+     */
+    val uiState: StateFlow<AccountUIState> = _uiState
+
+    private val _event = MutableSharedFlow<AccountEvent>()
+
+    /**
+     * Event flow to be observed.
+     */
+    val event: SharedFlow<AccountEvent> = _event
+
+    /**
+     * Sign out and navigate out of this screen.
+     */
+    fun signOut() {
+        viewModelScope.launch {
+            auth.signOut()
+            _event.emit(
+                AccountEvent.TriggerEdifikanaApplicationEvent(
+                    EdifikanaApplicationEvent.NavigateToActivity(ActivityRouteDestination.AuthDestination)
+                )
+            )
+        }
+    }
+}

--- a/edifikana/front-end/shared-compose/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/root/main/MainActivityScreen.kt
+++ b/edifikana/front-end/shared-compose/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/root/main/MainActivityScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -19,6 +20,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.cramsan.edifikana.client.lib.features.root.EdifikanaApplicationViewModel
 import com.cramsan.edifikana.client.lib.features.root.RouteSafePath
 import com.cramsan.edifikana.client.lib.features.root.main.eventlog.EventLogScreen
 import com.cramsan.edifikana.client.lib.features.root.main.eventlog.addrecord.AddRecordScreen
@@ -46,6 +48,7 @@ import org.koin.compose.koinInject
 @Composable
 fun MainActivityScreen(
     viewModel: MainActivityViewModel = koinInject(),
+    applicationViewModel: EdifikanaApplicationViewModel = koinInject(),
 ) {
     val navController = rememberNavController()
 
@@ -53,6 +56,23 @@ fun MainActivityScreen(
     val backStack by navController.currentBackStack.collectAsState()
     val currentDestination = navBackStackEntry?.destination
     var title by remember { mutableStateOf("") }
+
+    val event by viewModel.events.collectAsState(MainActivityEvent.Noop)
+    LaunchedEffect(event) {
+        when (val event = event) {
+            MainActivityEvent.Noop -> Unit
+            is MainActivityEvent.Navigate -> {
+                navController.navigate(event.destination.path)
+            }
+            is MainActivityEvent.NavigateBack -> {
+                navController.popBackStack()
+            }
+            is MainActivityEvent.NavigateToRootPage -> Unit
+            is MainActivityEvent.TriggerApplicationEvent -> {
+                applicationViewModel.executeEvent(event.applicationEvent)
+            }
+        }
+    }
 
     Scaffold(
         topBar = {

--- a/edifikana/front-end/shared-compose/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/root/main/MainActivityViewModel.kt
+++ b/edifikana/front-end/shared-compose/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/root/main/MainActivityViewModel.kt
@@ -1,7 +1,9 @@
 package com.cramsan.edifikana.client.lib.features.root.main
 
 import com.cramsan.edifikana.client.lib.features.base.EdifikanaBaseViewModel
+import com.cramsan.edifikana.client.lib.features.root.ActivityRouteDestination
 import com.cramsan.edifikana.client.lib.features.root.EdifikanaApplicationDelegatedEvent
+import com.cramsan.edifikana.client.lib.features.root.EdifikanaApplicationEvent
 import com.cramsan.framework.core.CoreUri
 import com.cramsan.framework.core.DispatcherProvider
 import com.cramsan.framework.logging.logI
@@ -68,7 +70,11 @@ class MainActivityViewModel(
      */
     fun navigateToAccount() {
         viewModelScope.launch {
-            TODO()
+            _events.emit(
+                MainActivityEvent.TriggerApplicationEvent(
+                    EdifikanaApplicationEvent.NavigateToActivity(ActivityRouteDestination.AccountDestination)
+                )
+            )
         }
     }
 

--- a/edifikana/front-end/shared-compose/src/jvmMain/kotlin/com/cramsan/edifikana/client/lib/features/root/account/account/AccountScreenPreview.kt
+++ b/edifikana/front-end/shared-compose/src/jvmMain/kotlin/com/cramsan/edifikana/client/lib/features/root/account/account/AccountScreenPreview.kt
@@ -1,0 +1,13 @@
+package com.cramsan.edifikana.client.lib.features.root.account.account
+
+import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.runtime.Composable
+
+@Preview
+@Composable
+private fun AccountScreenPreview() {
+    AccountContent(
+        content = AccountUIModel(""),
+        onSignOutClicked = {},
+    )
+}


### PR DESCRIPTION
This change adds the new Account page to the edifikana application. The code added follows the pre-existing architecture.
The new feature is added inside a new Account activity to host the Account page. 


