### PR TITLE
[EDIFIKANA] Separating client and BE auth settings

### DIFF
--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/di/ApplicationModule.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/di/ApplicationModule.kt
@@ -29,6 +29,7 @@ import com.cramsan.edifikana.server.core.service.password.SimplePasswordGenerato
 import com.cramsan.framework.assertlib.assertFalse
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.auth.Auth
+import io.github.jan.supabase.auth.SettingsSessionManager
 import io.github.jan.supabase.auth.auth
 import io.github.jan.supabase.createSupabaseClient
 import io.github.jan.supabase.postgrest.Postgrest
@@ -82,7 +83,9 @@ val ApplicationModule = module {
         ) {
             install(Postgrest)
             install(Storage)
-            install(Auth)
+            install(Auth) {
+                sessionManager = SettingsSessionManager(key = "$supabaseUrl-server")
+            }
         }
     }
 

--- a/edifikana/front-end/shared-compose/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/di/koin/ManagerModule.kt
+++ b/edifikana/front-end/shared-compose/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/di/koin/ManagerModule.kt
@@ -22,6 +22,7 @@ import com.cramsan.edifikana.client.lib.service.impl.TimeCardServiceImpl
 import com.cramsan.framework.core.ManagerDependencies
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.auth.Auth
+import io.github.jan.supabase.auth.SettingsSessionManager
 import io.github.jan.supabase.auth.auth
 import io.github.jan.supabase.compose.auth.ComposeAuth
 import io.github.jan.supabase.compose.auth.appleNativeLogin
@@ -63,6 +64,7 @@ val ManagerModule = module {
             install(Postgrest)
             install(Storage)
             install(Auth) {
+                sessionManager = SettingsSessionManager(key = "$supabaseUrl-client")
             }
             install(ComposeAuth) {
                 googleNativeLogin(


### PR DESCRIPTION
Previously the BE and client libraries of Supabase were saving their auth state into the same folder, causing changes in one of the applications to affect the other. This change adds a sufix to each application to separate those configs.

Also I am improving the `isSignedIn` function by adding a check that refreses the active token. This allows the client to consider itself signed out if the current token is not valid. In the future we will want to revisit this to make it more robust. 