### PR TITLE
[ALL][94] Enabling parametrized tests with JUnit5 for JVM targets only

### DIFF
--- a/gradle/kotlin-jvm-target-lib.gradle
+++ b/gradle/kotlin-jvm-target-lib.gradle
@@ -15,6 +15,7 @@ dependencies {
 
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:_"
     testImplementation "org.junit.jupiter:junit-jupiter-api:_"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:_"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit5:_"
     testImplementation "io.mockk:mockk:_"
 }

--- a/gradle/kotlin-mpp-target-jvm.gradle
+++ b/gradle/kotlin-mpp-target-jvm.gradle
@@ -23,6 +23,7 @@ kotlin {
             dependencies {
                 implementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:_"
                 implementation "org.junit.jupiter:junit-jupiter-api:_"
+                implementation "org.junit.jupiter:junit-jupiter-params:_"
                 implementation "org.jetbrains.kotlin:kotlin-test-junit5:_"
                 implementation "io.mockk:mockk:_"
 


### PR DESCRIPTION
Partially addresses #94 . This PR add support for parameterized for the JVM target only, Android, iOS, JS and wasm cannot support parameterized tests through `kotlin-test` for now. 

By having parameterized in the JVM target, we can at least have access to this capability and we can use it for cases in which we do not rely on platform specific capabilities. 