### PR TITLE
[ALL][BUILD] Identify orphan screenshot files 

### DIFF
--- a/.github/workflows/buildRelease.yml
+++ b/.github/workflows/buildRelease.yml
@@ -59,8 +59,9 @@ jobs:
           arguments: recordRoborazziDebug
       - name: Verify No Changes To Screenshots
         run: |
-          if [ -z "$(git status --porcelain)" ]; then
-            echo "No changes"
+          git status --porcelain
+          if [ -z "$?" ]; then
+            exit 0
           else
-            echo "Changes present"
+            exit 1
           fi

--- a/.github/workflows/buildRelease.yml
+++ b/.github/workflows/buildRelease.yml
@@ -59,9 +59,11 @@ jobs:
           arguments: recordRoborazziDebug
       - name: Verify No Changes To Screenshots
         run: |
-          git status --porcelain
-          if [ -z "$?" ]; then
+          git status
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "No changes to screenshots"
             exit 0
           else
+            echo "Changes to screenshots detected"
             exit 1
           fi


### PR DESCRIPTION
Improves the detection of changed screenshots. There was previously a gap in which a screenshot could be deleted and that would not trigger a failure. The orphaned files would cause no failure as the test only compare current results with existing screenshots. 

This is fixed by updating the GH action to do the following:
- Clear all screenshots
- Generate all screenshots
- `git status`
- If any file is missing, that was a case of a screenshot file without matching `@Preview`.

As part of this PR I am also re-enabling the Camera Preview's preview, which was removed in a previous commit. This missing preview was how we discovered about this gap in snapshot testing. 