### PR TITLE
[00][EDIFIKANA] Refactoring client Ktor DI

### DIFF
--- a/edifikana/front-end/shared-app/src/androidMain/kotlin/com/cramsan/edifikana/client/lib/di/koin/ExtrasPlatformModule.android.kt
+++ b/edifikana/front-end/shared-app/src/androidMain/kotlin/com/cramsan/edifikana/client/lib/di/koin/ExtrasPlatformModule.android.kt
@@ -1,32 +1,10 @@
 package com.cramsan.edifikana.client.lib.di.koin
 
-import com.cramsan.edifikana.client.lib.service.impl.AuthRequestPlugin
-import com.cramsan.edifikana.client.lib.settings.Overrides
-import com.cramsan.edifikana.lib.serialization.createJson
-import io.ktor.client.HttpClient
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.client.plugins.defaultRequest
-import io.ktor.serialization.kotlinx.json.json
 import org.koin.android.ext.koin.androidContext
-import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 actual val ExtrasPlatformModule = module {
 
     single { androidContext().contentResolver }
 
-    single {
-        HttpClient {
-            defaultRequest {
-                url("http://10.0.2.2:9292")
-            }
-            install(ContentNegotiation) {
-                json(createJson())
-            }
-            val disableSupabase = get<Boolean>(named(Overrides.KEY_DISABLE_SUPABASE))
-            if (!disableSupabase) {
-                install(AuthRequestPlugin(get()))
-            }
-        }
-    }
 }

--- a/edifikana/front-end/shared-app/src/androidMain/kotlin/com/cramsan/edifikana/client/lib/di/koin/ExtrasPlatformModule.android.kt
+++ b/edifikana/front-end/shared-app/src/androidMain/kotlin/com/cramsan/edifikana/client/lib/di/koin/ExtrasPlatformModule.android.kt
@@ -6,5 +6,4 @@ import org.koin.dsl.module
 actual val ExtrasPlatformModule = module {
 
     single { androidContext().contentResolver }
-
 }

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/di/koin/KtorModule.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/di/koin/KtorModule.kt
@@ -1,0 +1,30 @@
+package com.cramsan.edifikana.client.lib.di.koin
+
+import com.cramsan.edifikana.client.lib.service.impl.AuthRequestPlugin
+import com.cramsan.edifikana.client.lib.settings.Overrides
+import com.cramsan.edifikana.lib.serialization.createJson
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.serialization.kotlinx.json.json
+import org.koin.core.qualifier.named
+import org.koin.dsl.module
+
+internal val KtorModule = module {
+
+    single<HttpClient> {
+        HttpClient {
+            defaultRequest {
+                url("http://0.0.0.0:9292")
+            }
+            install(ContentNegotiation) {
+                json(createJson())
+            }
+            val disableSupabase = get<Boolean>(named(Overrides.KEY_DISABLE_SUPABASE))
+            if (!disableSupabase) {
+                install(AuthRequestPlugin(get()))
+            }
+        }
+    }
+
+}

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/di/koin/KtorModule.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/di/koin/KtorModule.kt
@@ -26,5 +26,4 @@ internal val KtorModule = module {
             }
         }
     }
-
 }

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/di/koin/Modules.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/di/koin/Modules.kt
@@ -1,11 +1,18 @@
 package com.cramsan.edifikana.client.lib.di.koin
 
+/**
+ * This file contains the list of Koin modules used in the application. Most modules are loaded on an as-needed basis.
+ * This means that the order in which they are loaded does not matter. Despite this we are keeping the order bases on
+ * the estimated dependency order of the modules. This is to make it easier to understand the dependencies between the
+ * modules.
+ */
 val moduleList = listOf(
     FrameworkModule,
     FrameworkPlatformDelegatesModule,
     SettingsModule,
     ExtrasModule,
     ExtrasPlatformModule,
+    KtorModule,
     ManagerModule,
     ManagerOverridesModule,
     ManagerPlatformModule,

--- a/edifikana/front-end/shared-app/src/jvmMain/kotlin/com/cramsan/edifikana/client/lib/di/koin/ExtrasPlatformModule.jvm.kt
+++ b/edifikana/front-end/shared-app/src/jvmMain/kotlin/com/cramsan/edifikana/client/lib/di/koin/ExtrasPlatformModule.jvm.kt
@@ -3,9 +3,9 @@ package com.cramsan.edifikana.client.lib.di.koin
 import androidx.room.Room
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import com.cramsan.edifikana.client.lib.db.AppDatabase
-import java.io.File
 import kotlinx.coroutines.Dispatchers
 import org.koin.dsl.module
+import java.io.File
 
 @Suppress("InjectDispatcher")
 actual val ExtrasPlatformModule = module {
@@ -24,5 +24,4 @@ actual val ExtrasPlatformModule = module {
             .setQueryCoroutineContext(Dispatchers.IO)
             .build()
     }
-
 }

--- a/edifikana/front-end/shared-app/src/jvmMain/kotlin/com/cramsan/edifikana/client/lib/di/koin/ExtrasPlatformModule.jvm.kt
+++ b/edifikana/front-end/shared-app/src/jvmMain/kotlin/com/cramsan/edifikana/client/lib/di/koin/ExtrasPlatformModule.jvm.kt
@@ -3,17 +3,9 @@ package com.cramsan.edifikana.client.lib.di.koin
 import androidx.room.Room
 import androidx.sqlite.driver.bundled.BundledSQLiteDriver
 import com.cramsan.edifikana.client.lib.db.AppDatabase
-import com.cramsan.edifikana.client.lib.service.impl.AuthRequestPlugin
-import com.cramsan.edifikana.client.lib.settings.Overrides
-import com.cramsan.edifikana.lib.serialization.createJson
-import io.ktor.client.HttpClient
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.client.plugins.defaultRequest
-import io.ktor.serialization.kotlinx.json.json
-import kotlinx.coroutines.Dispatchers
-import org.koin.core.qualifier.named
-import org.koin.dsl.module
 import java.io.File
+import kotlinx.coroutines.Dispatchers
+import org.koin.dsl.module
 
 @Suppress("InjectDispatcher")
 actual val ExtrasPlatformModule = module {
@@ -33,19 +25,4 @@ actual val ExtrasPlatformModule = module {
             .build()
     }
 
-    single {
-        HttpClient {
-            defaultRequest {
-                url("http://0.0.0.0:9292")
-            }
-            install(ContentNegotiation) {
-                json(createJson())
-            }
-
-            val disableSupabase = get<Boolean>(named(Overrides.KEY_DISABLE_SUPABASE))
-            if (!disableSupabase) {
-                install(AuthRequestPlugin(get()))
-            }
-        }
-    }
 }

--- a/edifikana/front-end/shared-app/src/wasmJsMain/kotlin/com/cramsan/edifikana/client/lib/di/koin/ExtrasPlatformModule.wasmJs.kt
+++ b/edifikana/front-end/shared-app/src/wasmJsMain/kotlin/com/cramsan/edifikana/client/lib/di/koin/ExtrasPlatformModule.wasmJs.kt
@@ -4,5 +4,4 @@ import org.koin.dsl.module
 
 @Suppress("InjectDispatcher")
 actual val ExtrasPlatformModule = module {
-
 }

--- a/edifikana/front-end/shared-app/src/wasmJsMain/kotlin/com/cramsan/edifikana/client/lib/di/koin/ExtrasPlatformModule.wasmJs.kt
+++ b/edifikana/front-end/shared-app/src/wasmJsMain/kotlin/com/cramsan/edifikana/client/lib/di/koin/ExtrasPlatformModule.wasmJs.kt
@@ -1,30 +1,8 @@
 package com.cramsan.edifikana.client.lib.di.koin
 
-import com.cramsan.edifikana.client.lib.service.impl.AuthRequestPlugin
-import com.cramsan.edifikana.client.lib.settings.Overrides
-import com.cramsan.edifikana.lib.serialization.createJson
-import io.ktor.client.HttpClient
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.client.plugins.defaultRequest
-import io.ktor.serialization.kotlinx.json.json
-import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 @Suppress("InjectDispatcher")
 actual val ExtrasPlatformModule = module {
 
-    single<HttpClient> {
-        HttpClient {
-            defaultRequest {
-                url("http://0.0.0.0:9292")
-            }
-            install(ContentNegotiation) {
-                json(createJson())
-            }
-            val disableSupabase = get<Boolean>(named(Overrides.KEY_DISABLE_SUPABASE))
-            if (!disableSupabase) {
-                install(AuthRequestPlugin(get()))
-            }
-        }
-    }
 }


### PR DESCRIPTION
The Ktor client was configured on the per-platform module. This meant that any changes needed to be updated on three places. This change centralizes the instantiation of the Ktor client in a single common module. 

From:
- [ExtrasPlatformModule.android.kt](https://github.com/CodeHavenX/MonoRepo/compare/cramsan/00_refactoring_ktor_di?expand=1#diff-80e0e6f92d327c8cc7d21d454a34910c9b3035824f9703954c6424f4c9f33617)
- [ExtrasPlatformModule.jvm.kt](https://github.com/CodeHavenX/MonoRepo/compare/cramsan/00_refactoring_ktor_di?expand=1#diff-1104dff0ef83f714a95fe87ad3ae9b364d9610d00c009f5457f0b1b2c1590faf)
- [ExtrasPlatformModule.wasmJs.kt](https://github.com/CodeHavenX/MonoRepo/compare/cramsan/00_refactoring_ktor_di?expand=1#diff-2b0c65c190a25de4e25b722898d46c5fcd2590aba147177aaf3f91e926fd2517)

To: [KtorModule.kt](https://github.com/CodeHavenX/MonoRepo/compare/cramsan/00_refactoring_ktor_di?expand=1#diff-22392865137cb0896818eea9a099bacd5905721809174cac6765f1866672aa45)