### PR TITLE
[EDIFIKANA][00] Fixing wrong invocation to event subscription

### DIFF
--- a/alpaca-scheduler/front-end/appcore/src/commonMain/kotlin/com/codehavenx/alpaca/frontend/appcore/features/application/AlpacaApplicationScreen.kt
+++ b/alpaca-scheduler/front-end/appcore/src/commonMain/kotlin/com/codehavenx/alpaca/frontend/appcore/features/application/AlpacaApplicationScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -61,14 +62,16 @@ fun AlpacaApplicationScreen(
         // Do something on create
     }
 
-    scope.launch {
-        viewModel.events.collect { applicationEvent ->
-            when (applicationEvent) {
-                is AlpacaApplicationViewModelEvent.AlpacaApplicationEventWrapper -> handleEvent(
-                    navController,
-                    viewModel,
-                    applicationEvent.event,
-                )
+    LaunchedEffect(scope) {
+        scope.launch {
+            viewModel.events.collect { applicationEvent ->
+                when (applicationEvent) {
+                    is AlpacaApplicationViewModelEvent.AlpacaApplicationEventWrapper -> handleEvent(
+                        navController,
+                        viewModel,
+                        applicationEvent.event,
+                    )
+                }
             }
         }
     }

--- a/alpaca-scheduler/front-end/appcore/src/commonMain/kotlin/com/codehavenx/alpaca/frontend/appcore/features/application/AlpacaApplicationScreen.kt
+++ b/alpaca-scheduler/front-end/appcore/src/commonMain/kotlin/com/codehavenx/alpaca/frontend/appcore/features/application/AlpacaApplicationScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -54,7 +53,6 @@ fun AlpacaApplicationScreen(
     @Suppress("UnusedParameter")
     eventHandler: PlatformEventHandler,
 ) {
-    val scope = rememberCoroutineScope()
     val uiState by viewModel.uiState.collectAsState()
     val navController = rememberNavController()
 
@@ -62,8 +60,8 @@ fun AlpacaApplicationScreen(
         // Do something on create
     }
 
-    LaunchedEffect(scope) {
-        scope.launch {
+    LaunchedEffect(Unit) {
+        launch {
             viewModel.events.collect { applicationEvent ->
                 when (applicationEvent) {
                     is AlpacaApplicationViewModelEvent.AlpacaApplicationEventWrapper -> handleEvent(

--- a/edifikana/front-end/shared-app/src/androidMain/kotlin/com/cramsan/edifikana/client/lib/features/main/camera/CameraActivity.kt
+++ b/edifikana/front-end/shared-app/src/androidMain/kotlin/com/cramsan/edifikana/client/lib/features/main/camera/CameraActivity.kt
@@ -7,6 +7,7 @@ import android.provider.Settings
 import androidx.activity.ComponentActivity
 import androidx.activity.addCallback
 import androidx.activity.compose.setContent
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
@@ -49,25 +50,28 @@ class CameraActivity : ComponentActivity() {
                 cameraDelegate.requestCameraPermission()
             }
 
-            scope.launch {
-                cameraDelegate.event.collect { event ->
-                    when (event) {
-                        is CameraEvent.CompleteFlow -> {
-                            setResult(
-                                RESULT_OK,
-                                Intent().apply {
-                                    putExtra(RESULT_URI, event.uri.toString())
-                                }
-                            )
-                            finish()
-                        }
-                        is CameraEvent.CancelFlow -> finish()
-                        is CameraEvent.OpenSettings -> {
-                            val intent = Intent(
-                                Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
-                                Uri.fromParts("package", this@CameraActivity.packageName, null)
-                            )
-                            startActivity(intent)
+            LaunchedEffect (scope) {
+                scope.launch {
+                    cameraDelegate.event.collect { event ->
+                        when (event) {
+                            is CameraEvent.CompleteFlow -> {
+                                setResult(
+                                    RESULT_OK,
+                                    Intent().apply {
+                                        putExtra(RESULT_URI, event.uri.toString())
+                                    }
+                                )
+                                finish()
+                            }
+
+                            is CameraEvent.CancelFlow -> finish()
+                            is CameraEvent.OpenSettings -> {
+                                val intent = Intent(
+                                    Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                                    Uri.fromParts("package", this@CameraActivity.packageName, null)
+                                )
+                                startActivity(intent)
+                            }
                         }
                     }
                 }

--- a/edifikana/front-end/shared-app/src/androidMain/kotlin/com/cramsan/edifikana/client/lib/features/main/camera/CameraActivity.kt
+++ b/edifikana/front-end/shared-app/src/androidMain/kotlin/com/cramsan/edifikana/client/lib/features/main/camera/CameraActivity.kt
@@ -50,7 +50,7 @@ class CameraActivity : ComponentActivity() {
                 cameraDelegate.requestCameraPermission()
             }
 
-            LaunchedEffect (scope) {
+            LaunchedEffect(scope) {
                 scope.launch {
                     cameraDelegate.event.collect { event ->
                         when (event) {

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/EdifikanaApplicationScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/EdifikanaApplicationScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -51,18 +52,20 @@ private fun ApplicationContent(
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
 
-    scope.launch {
-        viewModel.events.collect { event ->
-            when (event) {
-                is EdifikanaApplicationViewModelEvent.EdifikanaApplicationEventWrapper -> {
-                    handleApplicationEvent(
-                        eventHandler = eventHandler,
-                        navController = navController,
-                        scope = scope,
-                        snackbarHostState = snackbarHostState,
-                        viewModel = viewModel,
-                        applicationEvent = event.event,
-                    )
+    LaunchedEffect(scope) {
+        scope.launch {
+            viewModel.events.collect { event ->
+                when (event) {
+                    is EdifikanaApplicationViewModelEvent.EdifikanaApplicationEventWrapper -> {
+                        handleApplicationEvent(
+                            eventHandler = eventHandler,
+                            navController = navController,
+                            scope = scope,
+                            snackbarHostState = snackbarHostState,
+                            viewModel = viewModel,
+                            applicationEvent = event.event,
+                        )
+                    }
                 }
             }
         }

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/EdifikanaApplicationScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/EdifikanaApplicationScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -49,18 +48,17 @@ private fun ApplicationContent(
 ) {
     val navController = rememberNavController()
 
-    val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
 
-    LaunchedEffect(scope) {
-        scope.launch {
+    LaunchedEffect(Unit) {
+        launch {
             viewModel.events.collect { event ->
                 when (event) {
                     is EdifikanaApplicationViewModelEvent.EdifikanaApplicationEventWrapper -> {
                         handleApplicationEvent(
                             eventHandler = eventHandler,
                             navController = navController,
-                            scope = scope,
+                            scope = this,
                             snackbarHostState = snackbarHostState,
                             viewModel = viewModel,
                             applicationEvent = event.event,

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/account/account/AccountScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/account/account/AccountScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
@@ -50,10 +51,12 @@ fun AccountScreen(
     }
 
     val screenScope = rememberCoroutineScope()
-    screenScope.launch {
-        viewModel.events.collect { event ->
-            when (event) {
-                AccountEvent.Noop -> Unit
+    LaunchedEffect(screenScope) {
+        screenScope.launch {
+            viewModel.events.collect { event ->
+                when (event) {
+                    AccountEvent.Noop -> Unit
+                }
             }
         }
     }

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/account/account/AccountScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/account/account/AccountScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.Lifecycle
@@ -50,9 +49,8 @@ fun AccountScreen(
         viewModel.loadUserData()
     }
 
-    val screenScope = rememberCoroutineScope()
-    LaunchedEffect(screenScope) {
-        screenScope.launch {
+    LaunchedEffect(Unit) {
+        launch {
             viewModel.events.collect { event ->
                 when (event) {
                     AccountEvent.Noop -> Unit

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/account/notifications/NotificationsScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/account/notifications/NotificationsScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.Lifecycle
@@ -43,9 +42,8 @@ fun NotificationsScreen(
         // Call this feature's viewModel
     }
 
-    val screenScope = rememberCoroutineScope()
-    LaunchedEffect(screenScope) {
-        screenScope.launch {
+    LaunchedEffect(Unit) {
+        launch {
             viewModel.events.collect { event ->
                 when (event) {
                     NotificationsEvent.Noop -> Unit

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/account/notifications/NotificationsScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/account/notifications/NotificationsScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
@@ -43,10 +44,12 @@ fun NotificationsScreen(
     }
 
     val screenScope = rememberCoroutineScope()
-    screenScope.launch {
-        viewModel.events.collect { event ->
-            when (event) {
-                NotificationsEvent.Noop -> Unit
+    LaunchedEffect(screenScope) {
+        screenScope.launch {
+            viewModel.events.collect { event ->
+                when (event) {
+                    NotificationsEvent.Noop -> Unit
+                }
             }
         }
     }

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/admin/addprimarystaff/AddPrimaryStaffScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/admin/addprimarystaff/AddPrimaryStaffScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -54,10 +55,12 @@ fun AddPrimaryStaffScreen(
     }
 
     val screenScope = rememberCoroutineScope()
-    screenScope.launch {
-        viewModel.events.collect { event ->
-            when (event) {
-                AddPrimaryStaffEvent.Noop -> Unit
+    LaunchedEffect(screenScope) {
+        screenScope.launch {
+            viewModel.events.collect { event ->
+                when (event) {
+                    AddPrimaryStaffEvent.Noop -> Unit
+                }
             }
         }
     }

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/admin/addprimarystaff/AddPrimaryStaffScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/admin/addprimarystaff/AddPrimaryStaffScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -54,9 +53,8 @@ fun AddPrimaryStaffScreen(
         // Call this feature's viewModel
     }
 
-    val screenScope = rememberCoroutineScope()
-    LaunchedEffect(screenScope) {
-        screenScope.launch {
+    LaunchedEffect(Unit) {
+        launch {
             viewModel.events.collect { event ->
                 when (event) {
                     AddPrimaryStaffEvent.Noop -> Unit

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/admin/addproperty/AddPropertyScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/admin/addproperty/AddPropertyScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -50,9 +49,8 @@ fun AddPropertyScreen(
         // Call this feature's viewModel
     }
 
-    val screenScope = rememberCoroutineScope()
-    LaunchedEffect(screenScope) {
-        screenScope.launch {
+    LaunchedEffect(Unit) {
+        launch {
             viewModel.events.collect { event ->
                 when (event) {
                     AddPropertyEvent.Noop -> Unit

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/admin/addproperty/AddPropertyScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/admin/addproperty/AddPropertyScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -50,10 +51,12 @@ fun AddPropertyScreen(
     }
 
     val screenScope = rememberCoroutineScope()
-    screenScope.launch {
-        viewModel.events.collect { event ->
-            when (event) {
-                AddPropertyEvent.Noop -> Unit
+    LaunchedEffect(screenScope) {
+        screenScope.launch {
+            viewModel.events.collect { event ->
+                when (event) {
+                    AddPropertyEvent.Noop -> Unit
+                }
             }
         }
     }

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/admin/addsecondarystaff/AddSecondaryStaffScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/admin/addsecondarystaff/AddSecondaryStaffScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -62,9 +61,8 @@ fun AddSecondaryStaffScreen(
         // Call this feature's viewModel
     }
 
-    val screenScope = rememberCoroutineScope()
-    LaunchedEffect(screenScope) {
-        screenScope.launch {
+    LaunchedEffect(Unit) {
+        launch {
             viewModel.events.collect { event ->
                 when (event) {
                     AddSecondaryStaffEvent.Noop -> Unit

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/admin/addsecondarystaff/AddSecondaryStaffScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/admin/addsecondarystaff/AddSecondaryStaffScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -62,10 +63,12 @@ fun AddSecondaryStaffScreen(
     }
 
     val screenScope = rememberCoroutineScope()
-    screenScope.launch {
-        viewModel.events.collect { event ->
-            when (event) {
-                AddSecondaryStaffEvent.Noop -> Unit
+    LaunchedEffect(screenScope) {
+        screenScope.launch {
+            viewModel.events.collect { event ->
+                when (event) {
+                    AddSecondaryStaffEvent.Noop -> Unit
+                }
             }
         }
     }

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/admin/hub/HubScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/admin/hub/HubScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
@@ -43,10 +44,12 @@ fun HubScreen(
     val uiState by viewModel.uiState.collectAsState()
 
     val screenScope = rememberCoroutineScope()
-    screenScope.launch {
-        viewModel.events.collect { event ->
-            when (event) {
-                HubEvent.Noop -> Unit
+    LaunchedEffect(screenScope) {
+        screenScope.launch {
+            viewModel.events.collect { event ->
+                when (event) {
+                    HubEvent.Noop -> Unit
+                }
             }
         }
     }

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/admin/hub/HubScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/admin/hub/HubScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import com.cramsan.edifikana.client.lib.features.admin.properties.PropertyManagerScreen
 import com.cramsan.edifikana.client.lib.features.admin.stafflist.StaffListScreen
@@ -43,9 +42,8 @@ fun HubScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
 
-    val screenScope = rememberCoroutineScope()
-    LaunchedEffect(screenScope) {
-        screenScope.launch {
+    LaunchedEffect(Unit) {
+        launch {
             viewModel.events.collect { event ->
                 when (event) {
                     HubEvent.Noop -> Unit

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/admin/properties/PropertyManagerScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/admin/properties/PropertyManagerScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
@@ -50,9 +49,8 @@ fun PropertyManagerScreen(
         // Call this feature's viewModel
     }
 
-    val screenScope = rememberCoroutineScope()
-    LaunchedEffect(screenScope) {
-        screenScope.launch {
+    LaunchedEffect(Unit) {
+        launch {
             viewModel.events.collect { event ->
                 when (event) {
                     PropertyManagerEvent.Noop -> Unit

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/admin/properties/PropertyManagerScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/admin/properties/PropertyManagerScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
@@ -50,10 +51,12 @@ fun PropertyManagerScreen(
     }
 
     val screenScope = rememberCoroutineScope()
-    screenScope.launch {
-        viewModel.events.collect { event ->
-            when (event) {
-                PropertyManagerEvent.Noop -> Unit
+    LaunchedEffect(screenScope) {
+        screenScope.launch {
+            viewModel.events.collect { event ->
+                when (event) {
+                    PropertyManagerEvent.Noop -> Unit
+                }
             }
         }
     }

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/admin/property/PropertyScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/admin/property/PropertyScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -71,9 +70,8 @@ fun PropertyScreen(
         viewModel.loadContent(destination.propertyId)
     }
 
-    val screenScope = rememberCoroutineScope()
-    LaunchedEffect(screenScope) {
-        screenScope.launch {
+    LaunchedEffect(Unit) {
+        launch {
             viewModel.events.collect { event ->
                 when (event) {
                     PropertyEvent.ShowRemoveDialog -> {

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/admin/staff/StaffScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/admin/staff/StaffScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
@@ -46,10 +47,12 @@ fun StaffScreen(
     }
 
     val screenScope = rememberCoroutineScope()
-    screenScope.launch {
-        viewModel.events.collect { event ->
-            when (event) {
-                StaffEvent.Noop -> Unit
+    LaunchedEffect(screenScope) {
+        screenScope.launch {
+            viewModel.events.collect { event ->
+                when (event) {
+                    StaffEvent.Noop -> Unit
+                }
             }
         }
     }

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/admin/staff/StaffScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/admin/staff/StaffScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.Lifecycle
@@ -46,9 +45,8 @@ fun StaffScreen(
         // Call this feature's viewModel
     }
 
-    val screenScope = rememberCoroutineScope()
-    LaunchedEffect(screenScope) {
-        screenScope.launch {
+    LaunchedEffect(Unit) {
+        launch {
             viewModel.events.collect { event ->
                 when (event) {
                     StaffEvent.Noop -> Unit

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/admin/stafflist/StaffListScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/admin/stafflist/StaffListScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
@@ -56,10 +57,12 @@ fun StaffListScreen(
     }
 
     val screenScope = rememberCoroutineScope()
-    screenScope.launch {
-        viewModel.events.collect { event ->
-            when (event) {
-                StaffListEvent.Noop -> Unit
+    LaunchedEffect(screenScope) {
+        screenScope.launch {
+            viewModel.events.collect { event ->
+                when (event) {
+                    StaffListEvent.Noop -> Unit
+                }
             }
         }
     }

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/admin/stafflist/StaffListScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/admin/stafflist/StaffListScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
@@ -56,9 +55,8 @@ fun StaffListScreen(
         // Call this feature's viewModel
     }
 
-    val screenScope = rememberCoroutineScope()
-    LaunchedEffect(screenScope) {
-        screenScope.launch {
+    LaunchedEffect(Unit) {
+        launch {
             viewModel.events.collect { event ->
                 when (event) {
                     StaffListEvent.Noop -> Unit

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/auth/signin/SignInScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/auth/signin/SignInScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.Lifecycle
@@ -48,9 +47,8 @@ fun SignInScreen(
     LifecycleEventEffect(Lifecycle.Event.ON_STOP) {
     }
 
-    val screenScope = rememberCoroutineScope()
-    LaunchedEffect(screenScope) {
-        screenScope.launch {
+    LaunchedEffect(Unit) {
+        launch {
             viewModel.events.collect { event ->
                 when (event) {
                     SignInEvent.Noop -> Unit

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/auth/signin/SignInScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/auth/signin/SignInScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
@@ -48,10 +49,12 @@ fun SignInScreen(
     }
 
     val screenScope = rememberCoroutineScope()
-    screenScope.launch {
-        viewModel.events.collect { event ->
-            when (event) {
-                SignInEvent.Noop -> Unit
+    LaunchedEffect(screenScope) {
+        screenScope.launch {
+            viewModel.events.collect { event ->
+                when (event) {
+                    SignInEvent.Noop -> Unit
+                }
             }
         }
     }

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/auth/signup/SignUpScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/auth/signup/SignUpScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -64,10 +65,12 @@ fun SignUpScreen(
     }
 
     val screenScope = rememberCoroutineScope()
-    screenScope.launch {
-        viewModel.events.collect { event ->
-            when (event) {
-                SignUpEvent.Noop -> Unit
+    LaunchedEffect(screenScope) {
+        screenScope.launch {
+            viewModel.events.collect { event ->
+                when (event) {
+                    SignUpEvent.Noop -> Unit
+                }
             }
         }
     }

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/auth/signup/SignUpScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/auth/signup/SignUpScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -64,9 +63,8 @@ fun SignUpScreen(
     LifecycleEventEffect(Lifecycle.Event.ON_STOP) {
     }
 
-    val screenScope = rememberCoroutineScope()
-    LaunchedEffect(screenScope) {
-        screenScope.launch {
+    LaunchedEffect(Unit) {
+        launch {
             viewModel.events.collect { event ->
                 when (event) {
                     SignUpEvent.Noop -> Unit

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/auth/validation/ValidationScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/auth/validation/ValidationScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
@@ -45,10 +46,12 @@ fun ValidationScreen(
         // Call this feature's viewModel
     }
 
-    screenScope.launch {
-        viewModel.events.collect { event ->
-            when (event) {
-                ValidationEvent.Noop -> Unit
+    LaunchedEffect(screenScope) {
+        screenScope.launch {
+            viewModel.events.collect { event ->
+                when (event) {
+                    ValidationEvent.Noop -> Unit
+                }
             }
         }
     }

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/debug/main/DebugScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/debug/main/DebugScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -62,9 +61,8 @@ fun DebugScreen(
         viewModel.saveBufferedChanges()
     }
 
-    val screenScope = rememberCoroutineScope()
-    LaunchedEffect(screenScope) {
-        screenScope.launch {
+    LaunchedEffect(Unit) {
+        launch {
             viewModel.events.collect { event ->
                 when (event) {
                     DebugEvent.Noop -> Unit

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/debug/main/DebugScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/debug/main/DebugScreen.kt
@@ -249,9 +249,9 @@ private fun StringRow(
 }
 
 @Composable
-fun Modifier.hasLostFocus(onFocusLost: () -> Unit): Modifier {
+private fun Modifier.hasLostFocus(onFocusLost: () -> Unit): Modifier {
     var hasFocus by remember { mutableStateOf(false) }
-    var initialFocusState  by remember { mutableStateOf(true) }
+    var initialFocusState by remember { mutableStateOf(true) }
     LaunchedEffect(hasFocus, initialFocusState) {
         if (!hasFocus && !initialFocusState) {
             onFocusLost()

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/eventlog/EventLogScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/eventlog/EventLogScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -47,9 +46,8 @@ fun EventLogScreen(
         viewModel.loadRecords()
     }
 
-    val screenScope = rememberCoroutineScope()
-    LaunchedEffect(screenScope) {
-        screenScope.launch {
+    LaunchedEffect(Unit) {
+        launch {
             viewModel.events.collect { event ->
                 when (event) {
                     EventLogEvent.Noop -> Unit

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/eventlog/EventLogScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/eventlog/EventLogScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
@@ -47,10 +48,12 @@ fun EventLogScreen(
     }
 
     val screenScope = rememberCoroutineScope()
-    screenScope.launch {
-        viewModel.events.collect { event ->
-            when (event) {
-                EventLogEvent.Noop -> Unit
+    LaunchedEffect(screenScope) {
+        screenScope.launch {
+            viewModel.events.collect { event ->
+                when (event) {
+                    EventLogEvent.Noop -> Unit
+                }
             }
         }
     }

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/eventlog/addrecord/AddRecordScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/eventlog/addrecord/AddRecordScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -53,9 +52,8 @@ fun AddRecordScreen(
         viewModel.loadStaffs()
     }
 
-    val screenScope = rememberCoroutineScope()
-    LaunchedEffect(screenScope) {
-        screenScope.launch {
+    LaunchedEffect(Unit) {
+        launch {
             viewModel.events.collect { event ->
                 when (event) {
                     AddRecordEvent.Noop -> Unit

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/eventlog/addrecord/AddRecordScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/eventlog/addrecord/AddRecordScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -53,10 +54,12 @@ fun AddRecordScreen(
     }
 
     val screenScope = rememberCoroutineScope()
-    screenScope.launch {
-        viewModel.events.collect { event ->
-            when (event) {
-                AddRecordEvent.Noop -> Unit
+    LaunchedEffect(screenScope) {
+        screenScope.launch {
+            viewModel.events.collect { event ->
+                when (event) {
+                    AddRecordEvent.Noop -> Unit
+                }
             }
         }
     }

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/eventlog/viewrecord/ViewRecordScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/eventlog/viewrecord/ViewRecordScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
@@ -66,10 +67,12 @@ fun ViewRecordScreen(
     }
 
     val screenScope = rememberCoroutineScope()
-    screenScope.launch {
-        viewModel.events.collect { event ->
-            when (event) {
-                ViewRecordEvent.Noop -> Unit
+    LaunchedEffect(screenScope) {
+        screenScope.launch {
+            viewModel.events.collect { event ->
+                when (event) {
+                    ViewRecordEvent.Noop -> Unit
+                }
             }
         }
     }

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/eventlog/viewrecord/ViewRecordScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/eventlog/viewrecord/ViewRecordScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
@@ -66,9 +65,8 @@ fun ViewRecordScreen(
         viewModel.loadRecord(eventLogRecordPK)
     }
 
-    val screenScope = rememberCoroutineScope()
-    LaunchedEffect(screenScope) {
-        screenScope.launch {
+    LaunchedEffect(Unit) {
+        launch {
             viewModel.events.collect { event ->
                 when (event) {
                     ViewRecordEvent.Noop -> Unit
@@ -77,13 +75,15 @@ fun ViewRecordScreen(
         }
     }
 
-    screenScope.launch {
-        edifikanaApplicationViewModel.delegatedEvents.collect { event ->
-            when (event) {
-                is EdifikanaApplicationDelegatedEvent.HandleReceivedImages -> {
-                    viewModel.upload(event.uris)
+    LaunchedEffect(Unit) {
+        launch {
+            edifikanaApplicationViewModel.delegatedEvents.collect { event ->
+                when (event) {
+                    is EdifikanaApplicationDelegatedEvent.HandleReceivedImages -> {
+                        viewModel.upload(event.uris)
+                    }
+                    else -> Unit
                 }
-                else -> Unit
             }
         }
     }

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/home/HomeScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/home/HomeScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -79,9 +78,8 @@ fun HomeScreen(
         // Call this feature's viewModel
     }
 
-    val screenScope = rememberCoroutineScope()
-    LaunchedEffect(screenScope) {
-        screenScope.launch {
+    LaunchedEffect(Unit) {
+        launch {
             viewModel.events.collect { event ->
                 when (event) {
                     HomeEvent.Noop -> Unit

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/home/HomeScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/home/HomeScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -79,10 +80,12 @@ fun HomeScreen(
     }
 
     val screenScope = rememberCoroutineScope()
-    screenScope.launch {
-        viewModel.events.collect { event ->
-            when (event) {
-                HomeEvent.Noop -> Unit
+    LaunchedEffect(screenScope) {
+        screenScope.launch {
+            viewModel.events.collect { event ->
+                when (event) {
+                    HomeEvent.Noop -> Unit
+                }
             }
         }
     }

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/timecard/TimeCardScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/timecard/TimeCardScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
@@ -45,10 +46,12 @@ fun TimeCardScreen(
     }
 
     val screenScope = rememberCoroutineScope()
-    screenScope.launch {
-        viewModel.events.collect { event ->
-            when (event) {
-                TimeCardEvent.Noop -> Unit
+    LaunchedEffect(screenScope) {
+        screenScope.launch {
+            viewModel.events.collect { event ->
+                when (event) {
+                    TimeCardEvent.Noop -> Unit
+                }
             }
         }
     }

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/timecard/TimeCardScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/timecard/TimeCardScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
@@ -45,9 +44,8 @@ fun TimeCardScreen(
         viewModel.loadEvents()
     }
 
-    val screenScope = rememberCoroutineScope()
-    LaunchedEffect(screenScope) {
-        screenScope.launch {
+    LaunchedEffect(Unit) {
+        launch {
             viewModel.events.collect { event ->
                 when (event) {
                     TimeCardEvent.Noop -> Unit

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/timecard/stafflist/StaffListScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/timecard/stafflist/StaffListScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
@@ -39,10 +40,12 @@ fun StaffListScreen(
     }
 
     val screenScope = rememberCoroutineScope()
-    screenScope.launch {
-        viewModel.events.collect { event ->
-            when (event) {
-                StaffListEvent.Noop -> Unit
+    LaunchedEffect(screenScope) {
+        screenScope.launch {
+            viewModel.events.collect { event ->
+                when (event) {
+                    StaffListEvent.Noop -> Unit
+                }
             }
         }
     }

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/timecard/stafflist/StaffListScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/timecard/stafflist/StaffListScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.Lifecycle
@@ -39,9 +38,8 @@ fun StaffListScreen(
         viewModel.loadStaffs()
     }
 
-    val screenScope = rememberCoroutineScope()
-    LaunchedEffect(screenScope) {
-        screenScope.launch {
+    LaunchedEffect(Unit) {
+        launch {
             viewModel.events.collect { event ->
                 when (event) {
                     StaffListEvent.Noop -> Unit

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/timecard/viewstaff/ViewEmployeeScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/timecard/viewstaff/ViewEmployeeScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
@@ -59,10 +60,12 @@ fun ViewStaffScreen(
         viewModel.loadStaff(staffPK)
     }
 
-    screenScope.launch {
-        viewModel.events.collect { event ->
-            when (event) {
-                ViewStaffEvent.Noop -> Unit
+    LaunchedEffect(screenScope) {
+        screenScope.launch {
+            viewModel.events.collect { event ->
+                when (event) {
+                    ViewStaffEvent.Noop -> Unit
+                }
             }
         }
     }

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/timecard/viewstaff/ViewEmployeeScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/timecard/viewstaff/ViewEmployeeScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
@@ -54,14 +53,13 @@ fun ViewStaffScreen(
     edifikanaApplicationViewModel: EdifikanaApplicationViewModel = koinInject(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
-    val screenScope = rememberCoroutineScope()
 
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
         viewModel.loadStaff(staffPK)
     }
 
-    LaunchedEffect(screenScope) {
-        screenScope.launch {
+    LaunchedEffect(Unit) {
+        launch {
             viewModel.events.collect { event ->
                 when (event) {
                     ViewStaffEvent.Noop -> Unit
@@ -70,13 +68,16 @@ fun ViewStaffScreen(
         }
     }
 
-    screenScope.launch {
-        edifikanaApplicationViewModel.delegatedEvents.collect { event ->
-            when (event) {
-                is EdifikanaApplicationDelegatedEvent.HandleReceivedImage -> {
-                    viewModel.recordClockEvent(event.uri)
+    LaunchedEffect(Unit) {
+        launch {
+            edifikanaApplicationViewModel.delegatedEvents.collect { event ->
+                when (event) {
+                    is EdifikanaApplicationDelegatedEvent.HandleReceivedImage -> {
+                        viewModel.recordClockEvent(event.uri)
+                    }
+
+                    else -> Unit
                 }
-                else -> Unit
             }
         }
     }

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/management/drawer/ManagementScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/management/drawer/ManagementScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
@@ -49,9 +48,8 @@ fun ManagementScreen(
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
     val uiState by viewModel.uiState.collectAsState()
 
-    val screenScope = rememberCoroutineScope()
-    LaunchedEffect(screenScope) {
-        screenScope.launch {
+    LaunchedEffect(Unit) {
+        launch {
             viewModel.events.collect { event ->
                 when (event) {
                     ManagementEvent.ToggleDrawer -> {

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/management/drawer/ManagementScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/management/drawer/ManagementScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.NavigationDrawerItem
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
@@ -49,21 +50,23 @@ fun ManagementScreen(
     val uiState by viewModel.uiState.collectAsState()
 
     val screenScope = rememberCoroutineScope()
-    screenScope.launch {
-        viewModel.events.collect { event ->
-            when (event) {
-                ManagementEvent.ToggleDrawer -> {
-                    if (!drawerState.isAnimationRunning) {
-                        if (drawerState.isOpen) {
-                            drawerState.close()
-                        } else {
-                            drawerState.open()
+    LaunchedEffect(screenScope) {
+        screenScope.launch {
+            viewModel.events.collect { event ->
+                when (event) {
+                    ManagementEvent.ToggleDrawer -> {
+                        if (!drawerState.isAnimationRunning) {
+                            if (drawerState.isOpen) {
+                                drawerState.close()
+                            } else {
+                                drawerState.open()
+                            }
                         }
                     }
-                }
-                ManagementEvent.CloseDrawer -> {
-                    if (!drawerState.isAnimationRunning) {
-                        drawerState.close()
+                    ManagementEvent.CloseDrawer -> {
+                        if (!drawerState.isAnimationRunning) {
+                            drawerState.close()
+                        }
                     }
                 }
             }

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/splash/SplashScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/splash/SplashScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
@@ -35,10 +36,12 @@ fun SplashScreen(
     }
 
     val screenScope = rememberCoroutineScope()
-    screenScope.launch {
-        viewModel.events.collect { event ->
-            when (event) {
-                SplashEvent.Noop -> Unit
+    LaunchedEffect(screenScope) {
+        screenScope.launch {
+            viewModel.events.collect { event ->
+                when (event) {
+                    SplashEvent.Noop -> Unit
+                }
             }
         }
     }

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/splash/SplashScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/splash/SplashScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.Lifecycle
@@ -35,9 +34,8 @@ fun SplashScreen(
         viewModel.enforceAuth()
     }
 
-    val screenScope = rememberCoroutineScope()
-    LaunchedEffect(screenScope) {
-        screenScope.launch {
+    LaunchedEffect(Unit) {
+        launch {
             viewModel.events.collect { event ->
                 when (event) {
                     SplashEvent.Noop -> Unit

--- a/framework-samples/framework-sample-app/src/commonMain/kotlin/com/cramsan/framework/sample/shared/features/ApplicationScreen.kt
+++ b/framework-samples/framework-sample-app/src/commonMain/kotlin/com/cramsan/framework/sample/shared/features/ApplicationScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.navigation.NavHostController
@@ -37,16 +38,18 @@ private fun ApplicationContent(
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
 
-    scope.launch {
-        viewModel.events.collect { event ->
-            when (event) {
-                is SampleApplicationViewModelEvent.SampleApplicationEventWrapper -> {
-                    handleApplicationEvent(
-                        navController = navController,
-                        scope = scope,
-                        snackbarHostState = snackbarHostState,
-                        applicationEvent = event.event,
-                    )
+    LaunchedEffect(scope) {
+        scope.launch {
+            viewModel.events.collect { event ->
+                when (event) {
+                    is SampleApplicationViewModelEvent.SampleApplicationEventWrapper -> {
+                        handleApplicationEvent(
+                            navController = navController,
+                            scope = scope,
+                            snackbarHostState = snackbarHostState,
+                            applicationEvent = event.event,
+                        )
+                    }
                 }
             }
         }

--- a/framework-samples/framework-sample-app/src/commonMain/kotlin/com/cramsan/framework/sample/shared/features/ApplicationScreen.kt
+++ b/framework-samples/framework-sample-app/src/commonMain/kotlin/com/cramsan/framework/sample/shared/features/ApplicationScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.material3.SnackbarResult
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.rememberNavController
@@ -35,17 +34,16 @@ private fun ApplicationContent(
 ) {
     val navController = rememberNavController()
 
-    val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
 
-    LaunchedEffect(scope) {
-        scope.launch {
+    LaunchedEffect(Unit) {
+        launch {
             viewModel.events.collect { event ->
                 when (event) {
                     is SampleApplicationViewModelEvent.SampleApplicationEventWrapper -> {
                         handleApplicationEvent(
                             navController = navController,
-                            scope = scope,
+                            scope = this,
                             snackbarHostState = snackbarHostState,
                             applicationEvent = event.event,
                         )

--- a/framework-samples/framework-sample-app/src/commonMain/kotlin/com/cramsan/framework/sample/shared/features/main/halt/HaltUtilScreen.kt
+++ b/framework-samples/framework-sample-app/src/commonMain/kotlin/com/cramsan/framework/sample/shared/features/main/halt/HaltUtilScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
@@ -39,10 +40,12 @@ fun HaltUtilScreen(
         // Call this feature's viewModel
     }
 
-    screenScope.launch {
-        viewModel.events.collect { event ->
-            when (event) {
-                HaltUtilEvent.Noop -> Unit
+    LaunchedEffect(screenScope) {
+        screenScope.launch {
+            viewModel.events.collect { event ->
+                when (event) {
+                    HaltUtilEvent.Noop -> Unit
+                }
             }
         }
     }

--- a/framework-samples/framework-sample-app/src/commonMain/kotlin/com/cramsan/framework/sample/shared/features/main/halt/HaltUtilScreen.kt
+++ b/framework-samples/framework-sample-app/src/commonMain/kotlin/com/cramsan/framework/sample/shared/features/main/halt/HaltUtilScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
@@ -28,7 +27,6 @@ fun HaltUtilScreen(
     viewModel: HaltUtilViewModel = koinViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
-    val screenScope = rememberCoroutineScope()
 
     /**
      * For other possible lifecycle events, see the [Lifecycle.Event] documentation.
@@ -40,8 +38,8 @@ fun HaltUtilScreen(
         // Call this feature's viewModel
     }
 
-    LaunchedEffect(screenScope) {
-        screenScope.launch {
+    LaunchedEffect(Unit) {
+        launch {
             viewModel.events.collect { event ->
                 when (event) {
                     HaltUtilEvent.Noop -> Unit

--- a/framework-samples/framework-sample-app/src/commonMain/kotlin/com/cramsan/framework/sample/shared/features/main/menu/MainMenuScreen.kt
+++ b/framework-samples/framework-sample-app/src/commonMain/kotlin/com/cramsan/framework/sample/shared/features/main/menu/MainMenuScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
@@ -29,10 +30,12 @@ fun MainMenuScreen(
     LifecycleEventEffect(Lifecycle.Event.ON_STOP) {
     }
 
-    screenScope.launch {
-        viewModel.events.collect { event ->
-            when (event) {
-                MainMenuEvent.Noop -> Unit
+    LaunchedEffect(screenScope) {
+        screenScope.launch {
+            viewModel.events.collect { event ->
+                when (event) {
+                    MainMenuEvent.Noop -> Unit
+                }
             }
         }
     }

--- a/framework-samples/framework-sample-app/src/commonMain/kotlin/com/cramsan/framework/sample/shared/features/main/menu/MainMenuScreen.kt
+++ b/framework-samples/framework-sample-app/src/commonMain/kotlin/com/cramsan/framework/sample/shared/features/main/menu/MainMenuScreen.kt
@@ -6,8 +6,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
@@ -22,16 +20,14 @@ import org.koin.compose.viewmodel.koinViewModel
 fun MainMenuScreen(
     viewModel: MainMenuViewModel = koinViewModel(),
 ) {
-    val screenScope = rememberCoroutineScope()
-
     LifecycleEventEffect(Lifecycle.Event.ON_CREATE) {
     }
 
     LifecycleEventEffect(Lifecycle.Event.ON_STOP) {
     }
 
-    LaunchedEffect(screenScope) {
-        screenScope.launch {
+    LaunchedEffect(Unit) {
+        launch {
             viewModel.events.collect { event ->
                 when (event) {
                     MainMenuEvent.Noop -> Unit

--- a/ui-catalog/build.gradle.kts
+++ b/ui-catalog/build.gradle.kts
@@ -14,6 +14,7 @@ plugins {
 
 apply(from = "$rootDir/gradle/kotlin-mpp-target-common-compose.gradle")
 apply(from = "$rootDir/gradle/kotlin-mpp-target-android-lib-compose.gradle")
+apply(from = "$rootDir/gradle/kotlin-mpp-target-ios.gradle")
 apply(from = "$rootDir/gradle/kotlin-mpp-target-jvm-compose.gradle")
 apply(from = "$rootDir/gradle/kotlin-mpp-target-wasm.gradle")
 


### PR DESCRIPTION
Previously our screens were observing for viewmodel events by using this code:

```
 scope.launch {
        viewModel.events.collect { applicationEvent ->
            when (applicationEvent) {
                is AlpacaApplicationViewModelEvent.AlpacaApplicationEventWrapper -> handleEvent(
                    navController,
                    viewModel,
                    applicationEvent.event,
                )
            }
```

This was incorrect as the screen would recompose causing it to launch multiple jobs to observe the changes. 
The fix ensures that the observing is scoped only to the instance of the scope. 