### PR TITLE
[00] Multi window scopes for DI

### DIFF
--- a/edifikana/front-end/app-jvm/src/main/kotlin/com/cramsan/edifikana/client/desktop/EdifikanaApplication.kt
+++ b/edifikana/front-end/app-jvm/src/main/kotlin/com/cramsan/edifikana/client/desktop/EdifikanaApplication.kt
@@ -7,13 +7,12 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
-import com.cramsan.edifikana.client.lib.di.koin.windowModuleList
 import com.cramsan.edifikana.client.lib.features.ComposableKoinContext
 import com.cramsan.edifikana.client.lib.features.EdifikanaApplicationViewModel
 import com.cramsan.edifikana.client.lib.features.EdifikanaWindowScreen
 import com.cramsan.edifikana.client.lib.features.application.EdifikanaJvmMainScreenEventHandler
 import org.koin.compose.koinInject
-import org.koin.compose.module.rememberKoinModules
+import org.koin.compose.scope.KoinScope
 import org.koin.core.annotation.KoinExperimentalAPI
 
 /**
@@ -36,10 +35,11 @@ fun main() = application {
                 size = DpSize(600.dp, 800.dp)
             )
         ) {
-            rememberKoinModules { windowModuleList }
-            EdifikanaWindowScreen(
-                eventHandler = eventHandler,
-            )
+            KoinScope<String>("root-window") {
+                EdifikanaWindowScreen(
+                    eventHandler = eventHandler,
+                )
+            }
         }
     }
 }

--- a/edifikana/front-end/app-wasm/src/wasmJsMain/kotlin/com/cramsan/edifikana/client/wasm/Main.kt
+++ b/edifikana/front-end/app-wasm/src/wasmJsMain/kotlin/com/cramsan/edifikana/client/wasm/Main.kt
@@ -4,13 +4,12 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.window.CanvasBasedWindow
-import com.cramsan.edifikana.client.lib.di.koin.windowModuleList
 import com.cramsan.edifikana.client.lib.features.ComposableKoinContext
 import com.cramsan.edifikana.client.lib.features.EdifikanaApplicationViewModel
 import com.cramsan.edifikana.client.lib.features.EdifikanaWindowScreen
 import com.cramsan.edifikana.client.lib.features.application.EdifikanaWasmMainScreenEventHandler
 import org.koin.compose.koinInject
-import org.koin.compose.module.rememberKoinModules
+import org.koin.compose.scope.KoinScope
 
 /**
  * Main entry point for the application.
@@ -26,11 +25,11 @@ fun main() {
                 processViewModel.initialize()
             }
 
-            rememberKoinModules { windowModuleList }
-
-            EdifikanaWindowScreen(
-                eventHandler = eventHandler,
-            )
+            KoinScope<String>("root-window") {
+                EdifikanaWindowScreen(
+                    eventHandler = eventHandler,
+                )
+            }
         }
     }
 }

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/di/koin/ApplicationViewModelModule.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/di/koin/ApplicationViewModelModule.kt
@@ -2,7 +2,7 @@ package com.cramsan.edifikana.client.lib.di.koin
 
 import com.cramsan.edifikana.client.lib.features.EdifikanaApplicationViewModel
 import com.cramsan.framework.core.compose.ApplicationEvent
-import com.cramsan.framework.core.compose.ApplicationEventBus
+import com.cramsan.framework.core.compose.EventBus
 import com.cramsan.framework.core.compose.EventEmitter
 import com.cramsan.framework.core.compose.EventReceiver
 import com.cramsan.framework.core.compose.InvalidEventBus
@@ -15,37 +15,39 @@ import org.koin.dsl.module
 
 internal val ApplicationViewModelModule = module {
 
-    single(named(PROCESS_VIEW_MODEL_SCOPE)) {
-        ApplicationEventBus()
+    single(named(APPLICATION_EVENT_BUS)) {
+        EventBus<ApplicationEvent>()
     } withOptions {
         bind<EventReceiver<ApplicationEvent>>()
         bind<EventEmitter<ApplicationEvent>>()
     }
 
-    single(named(PROCESS_VIEW_MODEL_SCOPE)) {
+    single(named(APPLICATION_WINDOW_EVENT_BUS)) {
         InvalidEventBus<WindowEvent>()
     } withOptions {
         bind<EventReceiver<WindowEvent>>()
         bind<EventEmitter<WindowEvent>>()
     }
 
-    single(named(PROCESS_VIEW_MODEL_SCOPE)) {
+    single(named(APPLICATION_VIEW_MODEL_DEPENDENCIES)) {
         ViewModelDependencies(
             get(),
             get(),
             get(),
-            get(named(PROCESS_VIEW_MODEL_SCOPE)),
-            get(named(PROCESS_VIEW_MODEL_SCOPE)),
+            get(named(APPLICATION_WINDOW_EVENT_BUS)),
+            get(named(APPLICATION_EVENT_BUS)),
         )
     }
 
     single {
         EdifikanaApplicationViewModel(
             get(),
-            get(named(PROCESS_VIEW_MODEL_SCOPE)),
+            get(named(APPLICATION_VIEW_MODEL_DEPENDENCIES)),
             get(),
         )
     }
 }
 
-private const val PROCESS_VIEW_MODEL_SCOPE = "process_view_model_scope"
+const val APPLICATION_EVENT_BUS = "applicationEventBus"
+private const val APPLICATION_WINDOW_EVENT_BUS = "applicationWindowEventBus"
+private const val APPLICATION_VIEW_MODEL_DEPENDENCIES = "applicationViewModelDependencies"

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/di/koin/Modules.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/di/koin/Modules.kt
@@ -24,12 +24,6 @@ val moduleList = listOf(
     SupabaseModule,
     SupabaseOverridesModule,
     ApplicationViewModelModule,
-)
-
-/**
- * List of Koin modules that are loaded at the window level.
- */
-val windowModuleList = listOf(
     ViewModelModule,
     ViewModelPlatformModule,
 )

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/di/koin/ViewModelModule.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/di/koin/ViewModelModule.kt
@@ -24,14 +24,11 @@ import com.cramsan.edifikana.client.lib.features.main.timecard.TimeCartViewModel
 import com.cramsan.edifikana.client.lib.features.main.timecard.viewstaff.ViewStaffViewModel
 import com.cramsan.edifikana.client.lib.features.management.drawer.ManagementViewModel
 import com.cramsan.edifikana.client.lib.features.splash.SplashViewModel
-import com.cramsan.framework.core.compose.ApplicationEvent
-import com.cramsan.framework.core.compose.ApplicationEventBus
 import com.cramsan.framework.core.compose.EventBus
 import com.cramsan.framework.core.compose.EventEmitter
 import com.cramsan.framework.core.compose.EventReceiver
 import com.cramsan.framework.core.compose.ViewModelDependencies
 import com.cramsan.framework.core.compose.WindowEvent
-import com.cramsan.framework.core.compose.WindowEventBus
 import org.koin.core.module.dsl.bind
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.module.dsl.viewModelOf
@@ -43,71 +40,65 @@ typealias SelectStaffViewModel = com.cramsan.edifikana.client.lib.features.main.
 
 internal val ViewModelModule = module {
 
-    // These objects are singletons and are not scoped to any particular navigation graph.
-    single(named(APPLICATION_EVENT_SCOPE)) {
-        ApplicationEventBus()
-    } withOptions {
-        bind<EventReceiver<ApplicationEvent>>()
-        bind<EventEmitter<ApplicationEvent>>()
-    }
+    scope<String> {
+        scoped(named(VIEW_MODEL_WINDOW_EVENT_BUS)) {
+            EventBus<WindowEvent>()
+        } withOptions {
+            bind<EventEmitter<WindowEvent>>()
+            bind<EventReceiver<WindowEvent>>()
+        }
 
-    single(named(APPLICATION_EVENT_SCOPE)) {
-        WindowEventBus()
-    } withOptions {
-        bind<EventReceiver<WindowEvent>>()
-        bind<EventEmitter<WindowEvent>>()
-    }
+        scoped(named(VIEW_MODEL_DELEGATED_EVENT_BUS)) {
+            EventBus<EdifikanaWindowDelegatedEvent>()
+        } withOptions {
+            bind<EventEmitter<EdifikanaWindowDelegatedEvent>>()
+            bind<EventReceiver<EdifikanaWindowDelegatedEvent>>()
+        }
 
-    single(named(DELEGATED_EVENT_SCOPE)) {
-        EventBus<EdifikanaWindowDelegatedEvent>()
-    } withOptions {
-        bind<EventReceiver<EdifikanaWindowDelegatedEvent>>()
-        bind<EventEmitter<EdifikanaWindowDelegatedEvent>>()
-    }
+        scoped {
+            ViewModelDependencies(
+                get(),
+                get(),
+                get(),
+                get(named(VIEW_MODEL_WINDOW_EVENT_BUS)),
+                get(named(APPLICATION_EVENT_BUS)),
+            )
+        }
 
-    single {
-        ViewModelDependencies(
-            get(),
-            get(),
-            get(),
-            get(named(APPLICATION_EVENT_SCOPE)),
-            get(named(APPLICATION_EVENT_SCOPE)),
-        )
-    }
+        viewModel {
+            EdifikanaWindowViewModel(
+                get(),
+                get(named(VIEW_MODEL_WINDOW_EVENT_BUS)),
+                get(named(VIEW_MODEL_DELEGATED_EVENT_BUS)),
+            )
+        }
 
-    viewModel {
-        EdifikanaWindowViewModel(
-            get(),
-            get(named(APPLICATION_EVENT_SCOPE)),
-            get(named(DELEGATED_EVENT_SCOPE)),
-        )
+        // These objects are scoped to the screen in which they are used.
+        viewModelOf(::EventLogViewModel)
+        viewModelOf(::TimeCartViewModel)
+        viewModelOf(::StaffListViewModel)
+        viewModelOf(::ViewRecordViewModel)
+        viewModelOf(::AddRecordViewModel)
+        viewModelOf(::ViewStaffViewModel)
+        viewModelOf(::SignInViewModel)
+        viewModelOf(::SignUpViewModel)
+        viewModelOf(::AccountViewModel)
+        viewModelOf(::PropertyManagerViewModel)
+        viewModelOf(::PropertyViewModel)
+        viewModelOf(::DebugViewModel)
+        viewModelOf(::HomeViewModel)
+        viewModelOf(::ValidationViewModel)
+        viewModelOf(::AddPropertyViewModel)
+        viewModelOf(::HubViewModel)
+        viewModelOf(::AddPrimaryStaffViewModel)
+        viewModelOf(::AddSecondaryStaffViewModel)
+        viewModelOf(::StaffViewModel)
+        viewModelOf(::SelectStaffViewModel)
+        viewModelOf(::NotificationsViewModel)
+        viewModelOf(::SplashViewModel)
+        viewModelOf(::ManagementViewModel)
     }
-
-    // These objects are scoped to the screen in which they are used.
-    viewModelOf(::EventLogViewModel)
-    viewModelOf(::TimeCartViewModel)
-    viewModelOf(::StaffListViewModel)
-    viewModelOf(::ViewRecordViewModel)
-    viewModelOf(::AddRecordViewModel)
-    viewModelOf(::ViewStaffViewModel)
-    viewModelOf(::SignInViewModel)
-    viewModelOf(::SignUpViewModel)
-    viewModelOf(::AccountViewModel)
-    viewModelOf(::PropertyManagerViewModel)
-    viewModelOf(::PropertyViewModel)
-    viewModelOf(::DebugViewModel)
-    viewModelOf(::HomeViewModel)
-    viewModelOf(::ValidationViewModel)
-    viewModelOf(::AddPropertyViewModel)
-    viewModelOf(::HubViewModel)
-    viewModelOf(::AddPrimaryStaffViewModel)
-    viewModelOf(::AddSecondaryStaffViewModel)
-    viewModelOf(::StaffViewModel)
-    viewModelOf(::SelectStaffViewModel)
-    viewModelOf(::NotificationsViewModel)
-    viewModelOf(::SplashViewModel)
-    viewModelOf(::ManagementViewModel)
 }
 
-private const val APPLICATION_EVENT_SCOPE = "application_event_scope"
-private const val DELEGATED_EVENT_SCOPE = "delegated_event_scope"
+private const val VIEW_MODEL_WINDOW_EVENT_BUS = "viewModelWindowEventBus"
+const val VIEW_MODEL_DELEGATED_EVENT_BUS = "viewModelDelegatedEventBus"

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/EdifikanaWindowViewModel.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/EdifikanaWindowViewModel.kt
@@ -3,8 +3,8 @@ package com.cramsan.edifikana.client.lib.features
 import androidx.compose.material3.SnackbarResult
 import com.cramsan.framework.core.CoreUri
 import com.cramsan.framework.core.compose.BaseViewModel
-import com.cramsan.framework.core.compose.EventBus
 import com.cramsan.framework.core.compose.EventEmitter
+import com.cramsan.framework.core.compose.EventReceiver
 import com.cramsan.framework.core.compose.ViewModelDependencies
 import com.cramsan.framework.core.compose.WindowEvent
 import com.cramsan.framework.logging.logI
@@ -16,7 +16,7 @@ import kotlinx.coroutines.launch
 class EdifikanaWindowViewModel(
     dependencies: ViewModelDependencies,
     private val windowEventEmitter: EventEmitter<WindowEvent>,
-    private val delegatedEvents: EventBus<EdifikanaWindowDelegatedEvent>,
+    private val delegatedEvents: EventReceiver<EdifikanaWindowDelegatedEvent>,
 ) : BaseViewModel<EdifikanaWindowViewModelEvent, EdifikanaWindowUIState>(
     dependencies,
     EdifikanaWindowUIState,
@@ -24,13 +24,6 @@ class EdifikanaWindowViewModel(
 ) {
 
     init {
-        viewModelScope.launch {
-            delegatedEvents.events.collect {
-
-                logI(TAG, "Delegated event received: $it")
-            }
-        }
-
         viewModelScope.launch {
             windowEventEmitter.events.collect { event ->
                 logI(TAG, "Window event received: $event")
@@ -51,7 +44,7 @@ class EdifikanaWindowViewModel(
             logI(TAG, "Uri was null.")
         } else {
             logI(TAG, "Uri was received: $uri")
-            delegatedEvents.emit(EdifikanaWindowDelegatedEvent.HandleReceivedImage(uri))
+            delegatedEvents.push(EdifikanaWindowDelegatedEvent.HandleReceivedImage(uri))
         }
     }
 
@@ -63,7 +56,7 @@ class EdifikanaWindowViewModel(
             logI(TAG, "Uri list is empty.")
         } else {
             logI(TAG, "Uri list received with ${uris.count()} elements.")
-            delegatedEvents.emit(EdifikanaWindowDelegatedEvent.HandleReceivedImages(uris))
+            delegatedEvents.push(EdifikanaWindowDelegatedEvent.HandleReceivedImages(uris))
         }
     }
 
@@ -73,7 +66,7 @@ class EdifikanaWindowViewModel(
     fun handleSnackbarResult(result: SnackbarResult) {
         viewModelScope.launch {
             logI(TAG, "Result from snackbar: $result")
-            delegatedEvents.emit(EdifikanaWindowDelegatedEvent.HandleSnackbarResult(result))
+            delegatedEvents.push(EdifikanaWindowDelegatedEvent.HandleSnackbarResult(result))
         }
     }
 

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/eventlog/viewrecord/ViewRecordScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/eventlog/viewrecord/ViewRecordScreen.kt
@@ -35,7 +35,7 @@ import com.cramsan.edifikana.client.lib.features.EdifikanaWindowDelegatedEvent
 import com.cramsan.edifikana.client.lib.models.AttachmentHolder
 import com.cramsan.edifikana.client.ui.components.EdifikanaTopBar
 import com.cramsan.edifikana.lib.model.EventLogEntryId
-import com.cramsan.framework.core.compose.EventBus
+import com.cramsan.framework.core.compose.EventEmitter
 import com.cramsan.ui.components.LoadingAnimationOverlay
 import com.cramsan.ui.components.ScreenLayout
 import edifikana_lib.Res
@@ -57,7 +57,7 @@ import org.koin.compose.viewmodel.koinViewModel
 fun ViewRecordScreen(
     eventLogRecordPK: EventLogEntryId,
     viewModel: ViewRecordViewModel = koinViewModel(),
-    delegatedEventEmitter: EventBus<EdifikanaWindowDelegatedEvent> = koinInject(),
+    delegatedEventEmitter: EventEmitter<EdifikanaWindowDelegatedEvent> = koinInject(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
 

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/timecard/viewstaff/ViewEmployeeScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/main/timecard/viewstaff/ViewEmployeeScreen.kt
@@ -29,7 +29,7 @@ import com.cramsan.edifikana.client.ui.components.EdifikanaTopBar
 import com.cramsan.edifikana.lib.model.StaffId
 import com.cramsan.edifikana.lib.model.TimeCardEventId
 import com.cramsan.edifikana.lib.model.TimeCardEventType
-import com.cramsan.framework.core.compose.EventBus
+import com.cramsan.framework.core.compose.EventEmitter
 import com.cramsan.ui.components.ListCell
 import com.cramsan.ui.components.LoadingAnimationOverlay
 import com.cramsan.ui.components.ScreenLayout
@@ -50,7 +50,7 @@ import org.koin.compose.viewmodel.koinViewModel
 fun ViewStaffScreen(
     staffPK: StaffId,
     viewModel: ViewStaffViewModel = koinViewModel(),
-    delegatedEventEmitter: EventBus<EdifikanaWindowDelegatedEvent> = koinInject(),
+    delegatedEventEmitter: EventEmitter<EdifikanaWindowDelegatedEvent> = koinInject(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
 

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/account/account/AccountViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/account/account/AccountViewModelTest.kt
@@ -7,9 +7,10 @@ import com.cramsan.edifikana.client.lib.managers.AuthManager
 import com.cramsan.edifikana.client.lib.models.UserModel
 import com.cramsan.edifikana.lib.model.UserId
 import com.cramsan.framework.core.UnifiedDispatcherProvider
-import com.cramsan.framework.core.compose.ApplicationEventBus
+import com.cramsan.framework.core.compose.ApplicationEvent
+import com.cramsan.framework.core.compose.EventBus
 import com.cramsan.framework.core.compose.ViewModelDependencies
-import com.cramsan.framework.core.compose.WindowEventBus
+import com.cramsan.framework.core.compose.WindowEvent
 import com.cramsan.framework.logging.EventLogger
 import com.cramsan.framework.logging.implementation.PassthroughEventLogger
 import com.cramsan.framework.logging.implementation.StdOutEventLoggerDelegate
@@ -31,15 +32,15 @@ class AccountViewModelTest : TestBase() {
     private lateinit var authManager: AuthManager
     private lateinit var viewModel: AccountViewModel
     private lateinit var exceptionHandler: CollectorCoroutineExceptionHandler
-    private lateinit var windowEventBus: WindowEventBus
-    private lateinit var applicationEventReceiver: ApplicationEventBus
+    private lateinit var windowEventBus: EventBus<WindowEvent>
+    private lateinit var applicationEventReceiver: EventBus<ApplicationEvent>
 
     @BeforeEach
     fun setUp() {
         EventLogger.setInstance(PassthroughEventLogger(StdOutEventLoggerDelegate()))
         authManager = mockk()
-        applicationEventReceiver = ApplicationEventBus()
-        windowEventBus = WindowEventBus()
+        applicationEventReceiver = EventBus()
+        windowEventBus = EventBus()
         exceptionHandler = CollectorCoroutineExceptionHandler()
         val dependencies = ViewModelDependencies(
             appScope = testCoroutineScope,

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/account/notifications/NotificationsViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/account/notifications/NotificationsViewModelTest.kt
@@ -3,9 +3,10 @@ package com.cramsan.edifikana.client.lib.features.account.notifications
 import app.cash.turbine.test
 import com.cramsan.edifikana.client.lib.features.EdifikanaWindowsEvent
 import com.cramsan.framework.core.UnifiedDispatcherProvider
-import com.cramsan.framework.core.compose.ApplicationEventBus
+import com.cramsan.framework.core.compose.ApplicationEvent
+import com.cramsan.framework.core.compose.EventBus
 import com.cramsan.framework.core.compose.ViewModelDependencies
-import com.cramsan.framework.core.compose.WindowEventBus
+import com.cramsan.framework.core.compose.WindowEvent
 import com.cramsan.framework.logging.EventLogger
 import com.cramsan.framework.logging.implementation.PassthroughEventLogger
 import com.cramsan.framework.logging.implementation.StdOutEventLoggerDelegate
@@ -25,8 +26,8 @@ class NotificationsViewModelTest : TestBase() {
 
     private lateinit var viewModel: NotificationsViewModel
     private lateinit var exceptionHandler: CollectorCoroutineExceptionHandler
-    private lateinit var applicationEventReceiver: ApplicationEventBus
-    private lateinit var windowEventBus: WindowEventBus
+    private lateinit var applicationEventReceiver: EventBus<ApplicationEvent>
+    private lateinit var windowEventBus: EventBus<WindowEvent>
 
     /**
      * Setup the test.
@@ -34,8 +35,8 @@ class NotificationsViewModelTest : TestBase() {
     @BeforeEach
     fun setupTest() {
         EventLogger.setInstance(PassthroughEventLogger(StdOutEventLoggerDelegate()))
-        applicationEventReceiver = ApplicationEventBus()
-        windowEventBus = WindowEventBus()
+        applicationEventReceiver = EventBus()
+        windowEventBus = EventBus()
         exceptionHandler = CollectorCoroutineExceptionHandler()
         viewModel = NotificationsViewModel(
             dependencies = ViewModelDependencies(

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/admin/addprimarystaff/AddPrimaryStaffViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/admin/addprimarystaff/AddPrimaryStaffViewModelTest.kt
@@ -4,9 +4,10 @@ import app.cash.turbine.test
 import com.cramsan.edifikana.client.lib.features.EdifikanaWindowsEvent
 import com.cramsan.edifikana.client.lib.managers.StaffManager
 import com.cramsan.framework.core.UnifiedDispatcherProvider
-import com.cramsan.framework.core.compose.ApplicationEventBus
+import com.cramsan.framework.core.compose.ApplicationEvent
+import com.cramsan.framework.core.compose.EventBus
 import com.cramsan.framework.core.compose.ViewModelDependencies
-import com.cramsan.framework.core.compose.WindowEventBus
+import com.cramsan.framework.core.compose.WindowEvent
 import com.cramsan.framework.core.compose.resources.StringProvider
 import com.cramsan.framework.logging.EventLogger
 import com.cramsan.framework.logging.implementation.PassthroughEventLogger
@@ -31,15 +32,15 @@ class AddPrimaryStaffViewModelTest : TestBase() {
     private lateinit var viewModel: AddPrimaryStaffViewModel
     private lateinit var staffManager: StaffManager
     private lateinit var exceptionHandler: CollectorCoroutineExceptionHandler
-    private lateinit var applicationEventReceiver: ApplicationEventBus
+    private lateinit var applicationEventReceiver: EventBus<ApplicationEvent>
     private lateinit var stringProvider: StringProvider
-    private lateinit var windowEventBus: WindowEventBus
+    private lateinit var windowEventBus: EventBus<WindowEvent>
 
     @BeforeEach
     fun setupTest() {
         EventLogger.setInstance(PassthroughEventLogger(StdOutEventLoggerDelegate()))
-        applicationEventReceiver = ApplicationEventBus()
-        windowEventBus = WindowEventBus()
+        applicationEventReceiver = EventBus()
+        windowEventBus = EventBus()
         exceptionHandler = CollectorCoroutineExceptionHandler()
         staffManager = mockk(relaxed = true)
         stringProvider = mockk()

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/admin/addproperty/AddPropertyViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/admin/addproperty/AddPropertyViewModelTest.kt
@@ -6,9 +6,10 @@ import com.cramsan.edifikana.client.lib.managers.PropertyManager
 import com.cramsan.edifikana.client.lib.models.PropertyModel
 import com.cramsan.edifikana.lib.model.PropertyId
 import com.cramsan.framework.core.UnifiedDispatcherProvider
-import com.cramsan.framework.core.compose.ApplicationEventBus
+import com.cramsan.framework.core.compose.ApplicationEvent
+import com.cramsan.framework.core.compose.EventBus
 import com.cramsan.framework.core.compose.ViewModelDependencies
-import com.cramsan.framework.core.compose.WindowEventBus
+import com.cramsan.framework.core.compose.WindowEvent
 import com.cramsan.framework.logging.EventLogger
 import com.cramsan.framework.logging.implementation.PassthroughEventLogger
 import com.cramsan.framework.logging.implementation.StdOutEventLoggerDelegate
@@ -30,14 +31,14 @@ class AddPropertyViewModelTest : TestBase() {
     private lateinit var viewModel: AddPropertyViewModel
     private lateinit var propertyManager: PropertyManager
     private lateinit var exceptionHandler: CollectorCoroutineExceptionHandler
-    private lateinit var applicationEventReceiver: ApplicationEventBus
-    private lateinit var windowEventBus: WindowEventBus
+    private lateinit var applicationEventReceiver: EventBus<ApplicationEvent>
+    private lateinit var windowEventBus: EventBus<WindowEvent>
 
     @BeforeEach
     fun setupTest() {
         EventLogger.setInstance(PassthroughEventLogger(StdOutEventLoggerDelegate()))
-        applicationEventReceiver = ApplicationEventBus()
-        windowEventBus = WindowEventBus()
+        applicationEventReceiver = EventBus()
+        windowEventBus = EventBus()
         exceptionHandler = CollectorCoroutineExceptionHandler()
         propertyManager = mockk(relaxed = true)
         viewModel = AddPropertyViewModel(

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/admin/addsecondarystaff/AddSecondaryStaffViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/admin/addsecondarystaff/AddSecondaryStaffViewModelTest.kt
@@ -9,9 +9,10 @@ import com.cramsan.edifikana.lib.model.IdType
 import com.cramsan.edifikana.lib.model.PropertyId
 import com.cramsan.edifikana.lib.model.StaffRole
 import com.cramsan.framework.core.UnifiedDispatcherProvider
-import com.cramsan.framework.core.compose.ApplicationEventBus
+import com.cramsan.framework.core.compose.ApplicationEvent
+import com.cramsan.framework.core.compose.EventBus
 import com.cramsan.framework.core.compose.ViewModelDependencies
-import com.cramsan.framework.core.compose.WindowEventBus
+import com.cramsan.framework.core.compose.WindowEvent
 import com.cramsan.framework.core.compose.resources.StringProvider
 import com.cramsan.framework.logging.EventLogger
 import com.cramsan.framework.logging.implementation.PassthroughEventLogger
@@ -40,19 +41,19 @@ class AddSecondaryStaffViewModelTest : TestBase() {
     private lateinit var staffManager: StaffManager
     private lateinit var propertyManager: PropertyManager
     private lateinit var exceptionHandler: CollectorCoroutineExceptionHandler
-    private lateinit var applicationEventReceiver: ApplicationEventBus
-    private lateinit var windowEventBus: WindowEventBus
+    private lateinit var applicationEventReceiver: EventBus<ApplicationEvent>
+    private lateinit var windowEventBus: EventBus<WindowEvent>
     private lateinit var stringProvider: StringProvider
 
     @BeforeEach
     fun setupTest() {
         EventLogger.setInstance(PassthroughEventLogger(StdOutEventLoggerDelegate()))
-        applicationEventReceiver = ApplicationEventBus()
+        applicationEventReceiver = EventBus()
         exceptionHandler = CollectorCoroutineExceptionHandler()
         staffManager = mockk(relaxed = true)
         propertyManager = mockk(relaxed = true)
         stringProvider = mockk()
-        windowEventBus = WindowEventBus()
+        windowEventBus = EventBus()
         viewModel = AddSecondaryStaffViewModel(
             staffManager = staffManager,
             propertyManager = propertyManager,

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/admin/hub/HubViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/admin/hub/HubViewModelTest.kt
@@ -5,9 +5,10 @@ import com.cramsan.edifikana.client.lib.features.ActivityRouteDestination
 import com.cramsan.edifikana.client.lib.features.EdifikanaWindowsEvent
 import com.cramsan.edifikana.client.lib.features.account.AccountRouteDestination
 import com.cramsan.framework.core.UnifiedDispatcherProvider
-import com.cramsan.framework.core.compose.ApplicationEventBus
+import com.cramsan.framework.core.compose.ApplicationEvent
+import com.cramsan.framework.core.compose.EventBus
 import com.cramsan.framework.core.compose.ViewModelDependencies
-import com.cramsan.framework.core.compose.WindowEventBus
+import com.cramsan.framework.core.compose.WindowEvent
 import com.cramsan.framework.logging.EventLogger
 import com.cramsan.framework.logging.implementation.PassthroughEventLogger
 import com.cramsan.framework.logging.implementation.StdOutEventLoggerDelegate
@@ -24,14 +25,14 @@ class HubViewModelTest : TestBase() {
 
     private lateinit var viewModel: HubViewModel
     private lateinit var exceptionHandler: CollectorCoroutineExceptionHandler
-    private lateinit var windowEventBus: WindowEventBus
-    private lateinit var applicationEventReceiver: ApplicationEventBus
+    private lateinit var windowEventBus: EventBus<WindowEvent>
+    private lateinit var applicationEventReceiver: EventBus<ApplicationEvent>
 
     @BeforeEach
     fun setupTest() {
         EventLogger.setInstance(PassthroughEventLogger(StdOutEventLoggerDelegate()))
-        applicationEventReceiver = ApplicationEventBus()
-        windowEventBus = WindowEventBus()
+        applicationEventReceiver = EventBus()
+        windowEventBus = EventBus()
         exceptionHandler = CollectorCoroutineExceptionHandler()
         viewModel = HubViewModel(
             dependencies = ViewModelDependencies(

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/admin/properties/PropertyManagerViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/admin/properties/PropertyManagerViewModelTest.kt
@@ -7,9 +7,10 @@ import com.cramsan.edifikana.client.lib.managers.PropertyManager
 import com.cramsan.edifikana.client.lib.models.PropertyModel
 import com.cramsan.edifikana.lib.model.PropertyId
 import com.cramsan.framework.core.UnifiedDispatcherProvider
-import com.cramsan.framework.core.compose.ApplicationEventBus
+import com.cramsan.framework.core.compose.ApplicationEvent
+import com.cramsan.framework.core.compose.EventBus
 import com.cramsan.framework.core.compose.ViewModelDependencies
-import com.cramsan.framework.core.compose.WindowEventBus
+import com.cramsan.framework.core.compose.WindowEvent
 import com.cramsan.framework.logging.EventLogger
 import com.cramsan.framework.logging.implementation.PassthroughEventLogger
 import com.cramsan.framework.logging.implementation.StdOutEventLoggerDelegate
@@ -29,15 +30,15 @@ class PropertyManagerViewModelTest : TestBase() {
     private lateinit var viewModel: PropertyManagerViewModel
     private lateinit var propertyManager: PropertyManager
     private lateinit var exceptionHandler: CollectorCoroutineExceptionHandler
-    private lateinit var windowEventBus: WindowEventBus
-    private lateinit var applicationEventReceiver: ApplicationEventBus
+    private lateinit var windowEventBus: EventBus<WindowEvent>
+    private lateinit var applicationEventReceiver: EventBus<ApplicationEvent>
 
     @BeforeEach
     fun setupTest() {
         EventLogger.setInstance(PassthroughEventLogger(StdOutEventLoggerDelegate()))
-        applicationEventReceiver = ApplicationEventBus()
+        applicationEventReceiver = EventBus()
         exceptionHandler = CollectorCoroutineExceptionHandler()
-        windowEventBus = WindowEventBus()
+        windowEventBus = EventBus()
         propertyManager = mockk(relaxed = true)
         viewModel = PropertyManagerViewModel(
             dependencies = ViewModelDependencies(

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/admin/property/PropertyViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/admin/property/PropertyViewModelTest.kt
@@ -10,9 +10,10 @@ import com.cramsan.edifikana.lib.model.PropertyId
 import com.cramsan.framework.assertlib.AssertUtil
 import com.cramsan.framework.assertlib.implementation.NoopAssertUtil
 import com.cramsan.framework.core.UnifiedDispatcherProvider
-import com.cramsan.framework.core.compose.ApplicationEventBus
+import com.cramsan.framework.core.compose.ApplicationEvent
+import com.cramsan.framework.core.compose.EventBus
 import com.cramsan.framework.core.compose.ViewModelDependencies
-import com.cramsan.framework.core.compose.WindowEventBus
+import com.cramsan.framework.core.compose.WindowEvent
 import com.cramsan.framework.core.compose.resources.StringProvider
 import com.cramsan.framework.logging.EventLogger
 import com.cramsan.framework.logging.implementation.PassthroughEventLogger
@@ -38,16 +39,16 @@ class PropertyViewModelTest : TestBase() {
     private lateinit var propertyManager: PropertyManager
     private lateinit var staffManager: StaffManager
     private lateinit var exceptionHandler: CollectorCoroutineExceptionHandler
-    private lateinit var applicationEventReceiver: ApplicationEventBus
-    private lateinit var windowEventBus: WindowEventBus
+    private lateinit var applicationEventReceiver: EventBus<ApplicationEvent>
+    private lateinit var windowEventBus: EventBus<WindowEvent>
     private lateinit var stringProvider: StringProvider
 
     @BeforeEach
     fun setupTest() {
         EventLogger.setInstance(PassthroughEventLogger(StdOutEventLoggerDelegate()))
         AssertUtil.setInstance(NoopAssertUtil())
-        applicationEventReceiver = ApplicationEventBus()
-        windowEventBus = WindowEventBus()
+        applicationEventReceiver = EventBus()
+        windowEventBus = EventBus()
         exceptionHandler = CollectorCoroutineExceptionHandler()
         propertyManager = mockk(relaxed = true)
         staffManager = mockk(relaxed = true)

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/admin/staff/StaffViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/admin/staff/StaffViewModelTest.kt
@@ -9,9 +9,10 @@ import com.cramsan.edifikana.lib.model.StaffId
 import com.cramsan.edifikana.lib.model.StaffRole
 import com.cramsan.edifikana.lib.model.StaffStatus
 import com.cramsan.framework.core.UnifiedDispatcherProvider
-import com.cramsan.framework.core.compose.ApplicationEventBus
+import com.cramsan.framework.core.compose.ApplicationEvent
+import com.cramsan.framework.core.compose.EventBus
 import com.cramsan.framework.core.compose.ViewModelDependencies
-import com.cramsan.framework.core.compose.WindowEventBus
+import com.cramsan.framework.core.compose.WindowEvent
 import com.cramsan.framework.logging.EventLogger
 import com.cramsan.framework.logging.implementation.PassthroughEventLogger
 import com.cramsan.framework.logging.implementation.StdOutEventLoggerDelegate
@@ -32,14 +33,14 @@ class StaffViewModelTest : TestBase() {
     private lateinit var viewModel: StaffViewModel
     private lateinit var staffManager: StaffManager
     private lateinit var exceptionHandler: CollectorCoroutineExceptionHandler
-    private lateinit var applicationEventReceiver: ApplicationEventBus
-    private lateinit var windowEventBus: WindowEventBus
+    private lateinit var applicationEventReceiver: EventBus<ApplicationEvent>
+    private lateinit var windowEventBus: EventBus<WindowEvent>
 
     @BeforeEach
     fun setupTest() {
         EventLogger.setInstance(PassthroughEventLogger(StdOutEventLoggerDelegate()))
-        applicationEventReceiver = ApplicationEventBus()
-        windowEventBus = WindowEventBus()
+        applicationEventReceiver = EventBus()
+        windowEventBus = EventBus()
         exceptionHandler = CollectorCoroutineExceptionHandler()
         staffManager = mockk(relaxed = true)
         viewModel = StaffViewModel(

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/admin/stafflist/StaffListViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/admin/stafflist/StaffListViewModelTest.kt
@@ -10,9 +10,10 @@ import com.cramsan.edifikana.lib.model.StaffId
 import com.cramsan.edifikana.lib.model.StaffRole
 import com.cramsan.edifikana.lib.model.StaffStatus
 import com.cramsan.framework.core.UnifiedDispatcherProvider
-import com.cramsan.framework.core.compose.ApplicationEventBus
+import com.cramsan.framework.core.compose.ApplicationEvent
+import com.cramsan.framework.core.compose.EventBus
 import com.cramsan.framework.core.compose.ViewModelDependencies
-import com.cramsan.framework.core.compose.WindowEventBus
+import com.cramsan.framework.core.compose.WindowEvent
 import com.cramsan.framework.logging.EventLogger
 import com.cramsan.framework.logging.implementation.PassthroughEventLogger
 import com.cramsan.framework.logging.implementation.StdOutEventLoggerDelegate
@@ -33,16 +34,16 @@ class StaffListViewModelTest : TestBase() {
     private lateinit var viewModel: StaffListViewModel
     private lateinit var staffManager: StaffManager
     private lateinit var exceptionHandler: CollectorCoroutineExceptionHandler
-    private lateinit var applicationEventReceiver: ApplicationEventBus
-    private lateinit var windowEventBus: WindowEventBus
+    private lateinit var applicationEventReceiver: EventBus<ApplicationEvent>
+    private lateinit var windowEventBus: EventBus<WindowEvent>
 
     @BeforeEach
     fun setupTest() {
         EventLogger.setInstance(PassthroughEventLogger(StdOutEventLoggerDelegate()))
-        applicationEventReceiver = ApplicationEventBus()
+        applicationEventReceiver = EventBus()
         exceptionHandler = CollectorCoroutineExceptionHandler()
         staffManager = mockk(relaxed = true)
-        windowEventBus = WindowEventBus()
+        windowEventBus = EventBus()
         viewModel = StaffListViewModel(
             dependencies = ViewModelDependencies(
                 appScope = testCoroutineScope,

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/auth/signin/SignInViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/auth/signin/SignInViewModelTest.kt
@@ -7,9 +7,10 @@ import com.cramsan.edifikana.client.lib.features.auth.AuthRouteDestination
 import com.cramsan.edifikana.client.lib.managers.AuthManager
 import com.cramsan.edifikana.lib.utils.ClientRequestExceptions
 import com.cramsan.framework.core.UnifiedDispatcherProvider
-import com.cramsan.framework.core.compose.ApplicationEventBus
+import com.cramsan.framework.core.compose.ApplicationEvent
+import com.cramsan.framework.core.compose.EventBus
 import com.cramsan.framework.core.compose.ViewModelDependencies
-import com.cramsan.framework.core.compose.WindowEventBus
+import com.cramsan.framework.core.compose.WindowEvent
 import com.cramsan.framework.core.compose.resources.StringProvider
 import com.cramsan.framework.logging.EventLogger
 import com.cramsan.framework.logging.implementation.PassthroughEventLogger
@@ -40,8 +41,8 @@ class SignInViewModelTest : TestBase() {
     private lateinit var authManager: AuthManager
     private lateinit var viewModel: SignInViewModel
     private lateinit var exceptionHandler: CollectorCoroutineExceptionHandler
-    private lateinit var windowEventBus: WindowEventBus
-    private lateinit var applicationEventReceiver: ApplicationEventBus
+    private lateinit var windowEventBus: EventBus<WindowEvent>
+    private lateinit var applicationEventReceiver: EventBus<ApplicationEvent>
     private lateinit var stringProvider: StringProvider
 
     /**
@@ -51,8 +52,8 @@ class SignInViewModelTest : TestBase() {
     fun setupTest() {
         EventLogger.setInstance(PassthroughEventLogger(StdOutEventLoggerDelegate()))
         authManager = mockk()
-        applicationEventReceiver = ApplicationEventBus()
-        windowEventBus = WindowEventBus()
+        applicationEventReceiver = EventBus()
+        windowEventBus = EventBus()
         exceptionHandler = CollectorCoroutineExceptionHandler()
         stringProvider = mockk()
         viewModel = SignInViewModel(

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/auth/signup/SignUpViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/auth/signup/SignUpViewModelTest.kt
@@ -4,9 +4,10 @@ import app.cash.turbine.test
 import com.cramsan.edifikana.client.lib.features.EdifikanaWindowsEvent
 import com.cramsan.edifikana.client.lib.managers.AuthManager
 import com.cramsan.framework.core.UnifiedDispatcherProvider
-import com.cramsan.framework.core.compose.ApplicationEventBus
 import com.cramsan.framework.core.compose.ViewModelDependencies
-import com.cramsan.framework.core.compose.WindowEventBus
+import com.cramsan.framework.core.compose.ApplicationEvent
+import com.cramsan.framework.core.compose.EventBus
+import com.cramsan.framework.core.compose.WindowEvent
 import com.cramsan.framework.core.compose.resources.StringProvider
 import com.cramsan.framework.logging.EventLogger
 import com.cramsan.framework.logging.implementation.PassthroughEventLogger
@@ -38,8 +39,8 @@ class SignUpViewModelTest : TestBase() {
     private lateinit var authManager: AuthManager
     private lateinit var viewModel: SignUpViewModel
     private lateinit var exceptionHandler: CollectorCoroutineExceptionHandler
-    private lateinit var windowEventBus: WindowEventBus
-    private lateinit var applicationEventReceiver: ApplicationEventBus
+    private lateinit var windowEventBus: EventBus<WindowEvent>
+    private lateinit var applicationEventReceiver: EventBus<ApplicationEvent>
     private lateinit var stringProvider: StringProvider
 
 
@@ -51,8 +52,8 @@ class SignUpViewModelTest : TestBase() {
         EventLogger.setInstance(PassthroughEventLogger(StdOutEventLoggerDelegate()))
         authManager = mockk()
         exceptionHandler = CollectorCoroutineExceptionHandler()
-        applicationEventReceiver = ApplicationEventBus()
-        windowEventBus = WindowEventBus()
+        applicationEventReceiver = EventBus()
+        windowEventBus = EventBus()
         stringProvider = mockk()
         viewModel = SignUpViewModel(
             dependencies = ViewModelDependencies(

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/auth/validation/ValidationViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/auth/validation/ValidationViewModelTest.kt
@@ -3,9 +3,10 @@ package com.cramsan.edifikana.client.lib.features.auth.validation
 import com.cramsan.edifikana.client.lib.managers.AuthManager
 import com.cramsan.edifikana.client.lib.models.UserModel
 import com.cramsan.framework.core.UnifiedDispatcherProvider
-import com.cramsan.framework.core.compose.ApplicationEventBus
+import com.cramsan.framework.core.compose.ApplicationEvent
+import com.cramsan.framework.core.compose.EventBus
 import com.cramsan.framework.core.compose.ViewModelDependencies
-import com.cramsan.framework.core.compose.WindowEventBus
+import com.cramsan.framework.core.compose.WindowEvent
 import com.cramsan.framework.logging.EventLogger
 import com.cramsan.framework.logging.implementation.PassthroughEventLogger
 import com.cramsan.framework.logging.implementation.StdOutEventLoggerDelegate
@@ -29,9 +30,9 @@ class ValidationViewModelTest : TestBase() {
     private lateinit var authManager: AuthManager
     private lateinit var viewModel: ValidationViewModel
     private lateinit var exceptionHandler: CollectorCoroutineExceptionHandler
-    private lateinit var windowEventBus: WindowEventBus
+    private lateinit var windowEventBus: EventBus<WindowEvent>
 
-    private lateinit var applicationEventReceiver: ApplicationEventBus
+    private lateinit var applicationEventReceiver: EventBus<ApplicationEvent>
 
     /**
      * Setup the test.
@@ -41,8 +42,8 @@ class ValidationViewModelTest : TestBase() {
         EventLogger.setInstance(PassthroughEventLogger(StdOutEventLoggerDelegate()))
         authManager = mockk()
         exceptionHandler = CollectorCoroutineExceptionHandler()
-        windowEventBus = WindowEventBus()
-        applicationEventReceiver = ApplicationEventBus()
+        windowEventBus = EventBus()
+        applicationEventReceiver = EventBus()
         viewModel = ValidationViewModel(
             dependencies = ViewModelDependencies(
                 appScope = testCoroutineScope,

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/main/eventlog/EventLogViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/main/eventlog/EventLogViewModelTest.kt
@@ -10,9 +10,10 @@ import com.cramsan.edifikana.lib.model.EventLogEventType
 import com.cramsan.edifikana.lib.model.PropertyId
 import com.cramsan.edifikana.lib.model.StaffId
 import com.cramsan.framework.core.UnifiedDispatcherProvider
-import com.cramsan.framework.core.compose.ApplicationEventBus
+import com.cramsan.framework.core.compose.ApplicationEvent
+import com.cramsan.framework.core.compose.EventBus
 import com.cramsan.framework.core.compose.ViewModelDependencies
-import com.cramsan.framework.core.compose.WindowEventBus
+import com.cramsan.framework.core.compose.WindowEvent
 import com.cramsan.framework.core.compose.resources.StringProvider
 import com.cramsan.framework.logging.EventLogger
 import com.cramsan.framework.logging.implementation.PassthroughEventLogger
@@ -38,17 +39,17 @@ class EventLogViewModelTest : TestBase() {
     private lateinit var eventLogManager: EventLogManager
     private lateinit var viewModel: EventLogViewModel
     private lateinit var exceptionHandler: CollectorCoroutineExceptionHandler
-    private lateinit var applicationEventReceiver: ApplicationEventBus
+    private lateinit var applicationEventReceiver: EventBus<ApplicationEvent>
     private lateinit var stringProvider: StringProvider
-    private lateinit var windowEventBus: WindowEventBus
+    private lateinit var windowEventBus: EventBus<WindowEvent>
 
     @BeforeEach
     fun setUp() {
         EventLogger.setInstance(PassthroughEventLogger(StdOutEventLoggerDelegate()))
         eventLogManager = mockk()
         exceptionHandler = CollectorCoroutineExceptionHandler()
-        applicationEventReceiver = ApplicationEventBus()
-        windowEventBus = WindowEventBus()
+        applicationEventReceiver = EventBus()
+        windowEventBus = EventBus()
         stringProvider = mockk()
         val dependencies = ViewModelDependencies(
             appScope = testCoroutineScope,

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/main/eventlog/addrecord/AddRecordViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/main/eventlog/addrecord/AddRecordViewModelTest.kt
@@ -12,9 +12,10 @@ import com.cramsan.edifikana.lib.model.PropertyId
 import com.cramsan.edifikana.lib.model.StaffId
 import com.cramsan.framework.annotations.TestOnly
 import com.cramsan.framework.core.UnifiedDispatcherProvider
-import com.cramsan.framework.core.compose.ApplicationEventBus
+import com.cramsan.framework.core.compose.ApplicationEvent
+import com.cramsan.framework.core.compose.EventBus
 import com.cramsan.framework.core.compose.ViewModelDependencies
-import com.cramsan.framework.core.compose.WindowEventBus
+import com.cramsan.framework.core.compose.WindowEvent
 import com.cramsan.framework.core.compose.resources.StringProvider
 import com.cramsan.framework.logging.EventLogger
 import com.cramsan.framework.logging.implementation.PassthroughEventLogger
@@ -43,8 +44,8 @@ class AddRecordViewModelTest : TestBase() {
     private lateinit var staffManager: StaffManager
     private lateinit var viewModel: AddRecordViewModel
     private lateinit var exceptionHandler: CollectorCoroutineExceptionHandler
-    private lateinit var applicationEventReceiver: ApplicationEventBus
-    private lateinit var windowEventBus: WindowEventBus
+    private lateinit var applicationEventReceiver: EventBus<ApplicationEvent>
+    private lateinit var windowEventBus: EventBus<WindowEvent>
     private lateinit var clock: Clock
     private lateinit var propertyManager: PropertyManager
     private lateinit var stringProvider: StringProvider
@@ -57,8 +58,8 @@ class AddRecordViewModelTest : TestBase() {
         eventLogManager = mockk()
         propertyManager = mockk()
         exceptionHandler = CollectorCoroutineExceptionHandler()
-        applicationEventReceiver = ApplicationEventBus()
-        windowEventBus = WindowEventBus()
+        applicationEventReceiver = EventBus()
+        windowEventBus = EventBus()
         stringProvider = mockk()
         val dependencies = ViewModelDependencies(
             appScope = testCoroutineScope,

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/main/eventlog/viewrecord/ViewRecordViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/main/eventlog/viewrecord/ViewRecordViewModelTest.kt
@@ -11,9 +11,10 @@ import com.cramsan.edifikana.lib.model.EventLogEventType
 import com.cramsan.edifikana.lib.model.PropertyId
 import com.cramsan.framework.core.CoreUri
 import com.cramsan.framework.core.UnifiedDispatcherProvider
-import com.cramsan.framework.core.compose.ApplicationEventBus
+import com.cramsan.framework.core.compose.ApplicationEvent
+import com.cramsan.framework.core.compose.EventBus
 import com.cramsan.framework.core.compose.ViewModelDependencies
-import com.cramsan.framework.core.compose.WindowEventBus
+import com.cramsan.framework.core.compose.WindowEvent
 import com.cramsan.framework.core.compose.resources.StringProvider
 import com.cramsan.framework.logging.EventLogger
 import com.cramsan.framework.logging.implementation.PassthroughEventLogger
@@ -39,8 +40,8 @@ class ViewRecordViewModelTest : TestBase() {
     private lateinit var storageService: StorageService
     private lateinit var viewModel: ViewRecordViewModel
     private lateinit var exceptionHandler: CollectorCoroutineExceptionHandler
-    private lateinit var applicationEventReceiver: ApplicationEventBus
-    private lateinit var windowEventBus: WindowEventBus
+    private lateinit var applicationEventReceiver: EventBus<ApplicationEvent>
+    private lateinit var windowEventBus: EventBus<WindowEvent>
     private lateinit var stringProvider: StringProvider
 
     @BeforeEach
@@ -49,8 +50,8 @@ class ViewRecordViewModelTest : TestBase() {
         eventLogManager = mockk()
         storageService = mockk()
         exceptionHandler = CollectorCoroutineExceptionHandler()
-        applicationEventReceiver = ApplicationEventBus()
-        windowEventBus = WindowEventBus()
+        applicationEventReceiver = EventBus()
+        windowEventBus = EventBus()
         stringProvider = mockk()
         val dependencies = ViewModelDependencies(
             appScope = testCoroutineScope,

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/main/home/HomeViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/main/home/HomeViewModelTest.kt
@@ -8,9 +8,10 @@ import com.cramsan.edifikana.client.lib.managers.PropertyManager
 import com.cramsan.edifikana.client.lib.models.PropertyModel
 import com.cramsan.edifikana.lib.model.PropertyId
 import com.cramsan.framework.core.UnifiedDispatcherProvider
-import com.cramsan.framework.core.compose.ApplicationEventBus
+import com.cramsan.framework.core.compose.ApplicationEvent
+import com.cramsan.framework.core.compose.EventBus
 import com.cramsan.framework.core.compose.ViewModelDependencies
-import com.cramsan.framework.core.compose.WindowEventBus
+import com.cramsan.framework.core.compose.WindowEvent
 import com.cramsan.framework.logging.EventLogger
 import com.cramsan.framework.logging.implementation.PassthroughEventLogger
 import com.cramsan.framework.logging.implementation.StdOutEventLoggerDelegate
@@ -32,16 +33,16 @@ class HomeViewModelTest : TestBase() {
     private lateinit var propertyManager: PropertyManager
     private lateinit var viewModel: HomeViewModel
     private lateinit var exceptionHandler: CollectorCoroutineExceptionHandler
-    private lateinit var applicationEventReceiver: ApplicationEventBus
-    private lateinit var windowEventBus: WindowEventBus
+    private lateinit var applicationEventReceiver: EventBus<ApplicationEvent>
+    private lateinit var windowEventBus: EventBus<WindowEvent>
 
     @BeforeEach
     fun setUp() {
         EventLogger.setInstance(PassthroughEventLogger(StdOutEventLoggerDelegate()))
         propertyManager = mockk()
         exceptionHandler = CollectorCoroutineExceptionHandler()
-        applicationEventReceiver = ApplicationEventBus()
-        windowEventBus = WindowEventBus()
+        applicationEventReceiver = EventBus()
+        windowEventBus = EventBus()
         val dependencies = ViewModelDependencies(
             appScope = testCoroutineScope,
             dispatcherProvider = UnifiedDispatcherProvider(testCoroutineDispatcher),

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/main/timecard/TimeCartViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/main/timecard/TimeCartViewModelTest.kt
@@ -15,9 +15,10 @@ import com.cramsan.edifikana.lib.model.StaffStatus
 import com.cramsan.edifikana.lib.model.TimeCardEventId
 import com.cramsan.edifikana.lib.model.TimeCardEventType
 import com.cramsan.framework.core.UnifiedDispatcherProvider
-import com.cramsan.framework.core.compose.ApplicationEventBus
+import com.cramsan.framework.core.compose.ApplicationEvent
+import com.cramsan.framework.core.compose.EventBus
 import com.cramsan.framework.core.compose.ViewModelDependencies
-import com.cramsan.framework.core.compose.WindowEventBus
+import com.cramsan.framework.core.compose.WindowEvent
 import com.cramsan.framework.core.compose.resources.StringProvider
 import com.cramsan.framework.logging.EventLogger
 import com.cramsan.framework.logging.implementation.PassthroughEventLogger
@@ -44,8 +45,8 @@ class TimeCartViewModelTest : TestBase() {
     private lateinit var staffManager: StaffManager
     private lateinit var viewModel: TimeCartViewModel
     private lateinit var exceptionHandler: CollectorCoroutineExceptionHandler
-    private lateinit var applicationEventReceiver: ApplicationEventBus
-    private lateinit var windowEventBus: WindowEventBus
+    private lateinit var applicationEventReceiver: EventBus<ApplicationEvent>
+    private lateinit var windowEventBus: EventBus<WindowEvent>
     private lateinit var stringProvider: StringProvider
 
     @BeforeEach
@@ -54,8 +55,8 @@ class TimeCartViewModelTest : TestBase() {
         timeCardManager = mockk()
         staffManager = mockk()
         exceptionHandler = CollectorCoroutineExceptionHandler()
-        applicationEventReceiver = ApplicationEventBus()
-        windowEventBus = WindowEventBus()
+        applicationEventReceiver = EventBus()
+        windowEventBus = EventBus()
         stringProvider = mockk()
         val dependencies = ViewModelDependencies(
             appScope = testCoroutineScope,

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/main/timecard/stafflist/StaffListViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/main/timecard/stafflist/StaffListViewModelTest.kt
@@ -10,9 +10,10 @@ import com.cramsan.edifikana.lib.model.StaffId
 import com.cramsan.edifikana.lib.model.StaffRole
 import com.cramsan.edifikana.lib.model.StaffStatus
 import com.cramsan.framework.core.UnifiedDispatcherProvider
-import com.cramsan.framework.core.compose.ApplicationEventBus
+import com.cramsan.framework.core.compose.ApplicationEvent
+import com.cramsan.framework.core.compose.EventBus
 import com.cramsan.framework.core.compose.ViewModelDependencies
-import com.cramsan.framework.core.compose.WindowEventBus
+import com.cramsan.framework.core.compose.WindowEvent
 import com.cramsan.framework.core.compose.resources.StringProvider
 import com.cramsan.framework.logging.EventLogger
 import com.cramsan.framework.logging.implementation.PassthroughEventLogger
@@ -36,8 +37,8 @@ class StaffListViewModelTest : TestBase() {
     private lateinit var staffManager: StaffManager
     private lateinit var viewModel: StaffListViewModel
     private lateinit var exceptionHandler: CollectorCoroutineExceptionHandler
-    private lateinit var applicationEventReceiver: ApplicationEventBus
-    private lateinit var windowEventBus: WindowEventBus
+    private lateinit var applicationEventReceiver: EventBus<ApplicationEvent>
+    private lateinit var windowEventBus: EventBus<WindowEvent>
     private lateinit var stringProvider: StringProvider
 
     @BeforeEach
@@ -45,8 +46,8 @@ class StaffListViewModelTest : TestBase() {
         EventLogger.setInstance(PassthroughEventLogger(StdOutEventLoggerDelegate()))
         staffManager = mockk()
         exceptionHandler = CollectorCoroutineExceptionHandler()
-        applicationEventReceiver = ApplicationEventBus()
-        windowEventBus = WindowEventBus()
+        applicationEventReceiver = EventBus()
+        windowEventBus = EventBus()
         stringProvider = mockk()
         val dependencies = ViewModelDependencies(
             appScope = testCoroutineScope,

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/main/timecard/viewstaff/ViewStaffViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/main/timecard/viewstaff/ViewStaffViewModelTest.kt
@@ -18,9 +18,10 @@ import com.cramsan.edifikana.lib.model.TimeCardEventType
 import com.cramsan.framework.annotations.TestOnly
 import com.cramsan.framework.core.CoreUri
 import com.cramsan.framework.core.UnifiedDispatcherProvider
-import com.cramsan.framework.core.compose.ApplicationEventBus
+import com.cramsan.framework.core.compose.ApplicationEvent
+import com.cramsan.framework.core.compose.EventBus
 import com.cramsan.framework.core.compose.ViewModelDependencies
-import com.cramsan.framework.core.compose.WindowEventBus
+import com.cramsan.framework.core.compose.WindowEvent
 import com.cramsan.framework.core.compose.resources.StringProvider
 import com.cramsan.framework.logging.EventLogger
 import com.cramsan.framework.logging.implementation.PassthroughEventLogger
@@ -53,8 +54,8 @@ class ViewStaffViewModelTest : TestBase() {
     private lateinit var propertyManager: PropertyManager
     private lateinit var viewModel: ViewStaffViewModel
     private lateinit var exceptionHandler: CollectorCoroutineExceptionHandler
-    private lateinit var windowEventBus: WindowEventBus
-    private lateinit var applicationEventReceiver: ApplicationEventBus
+    private lateinit var windowEventBus: EventBus<WindowEvent>
+    private lateinit var applicationEventReceiver: EventBus<ApplicationEvent>
     private lateinit var stringProvider: StringProvider
 
     @BeforeEach
@@ -65,8 +66,8 @@ class ViewStaffViewModelTest : TestBase() {
         storageService = mockk()
         propertyManager = mockk()
         exceptionHandler = CollectorCoroutineExceptionHandler()
-        applicationEventReceiver = ApplicationEventBus()
-        windowEventBus = WindowEventBus()
+        applicationEventReceiver = EventBus()
+        windowEventBus = EventBus()
         val dependencies = ViewModelDependencies(
             appScope = testCoroutineScope,
             dispatcherProvider = UnifiedDispatcherProvider(testCoroutineDispatcher),

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/management/drawer/ManagementViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/management/drawer/ManagementViewModelTest.kt
@@ -2,9 +2,10 @@ package com.cramsan.edifikana.client.lib.features.management.drawer
 
 import com.cramsan.edifikana.client.lib.features.EdifikanaWindowsEvent
 import com.cramsan.framework.core.UnifiedDispatcherProvider
-import com.cramsan.framework.core.compose.ApplicationEventBus
+import com.cramsan.framework.core.compose.ApplicationEvent
+import com.cramsan.framework.core.compose.EventBus
 import com.cramsan.framework.core.compose.ViewModelDependencies
-import com.cramsan.framework.core.compose.WindowEventBus
+import com.cramsan.framework.core.compose.WindowEvent
 import com.cramsan.framework.logging.EventLogger
 import com.cramsan.framework.test.CollectorCoroutineExceptionHandler
 import com.cramsan.framework.test.TestBase
@@ -29,9 +30,9 @@ class ManagementViewModelTest : TestBase() {
 
     private lateinit var exceptionHandler: CollectorCoroutineExceptionHandler
 
-    private lateinit var applicationEventReceiver: ApplicationEventBus
+    private lateinit var applicationEventReceiver: EventBus<ApplicationEvent>
 
-    private lateinit var windowEventBus: WindowEventBus
+    private lateinit var windowEventBus: EventBus<WindowEvent>
 
 
     @BeforeTest
@@ -65,6 +66,6 @@ class ManagementViewModelTest : TestBase() {
         viewModel.onBackSelected()
 
         // Assert
-        coVerify { windowEventBus.emit(EdifikanaWindowsEvent.NavigateBack) }
+        coVerify { windowEventBus.push(EdifikanaWindowsEvent.NavigateBack) }
     }
 }

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/splash/SplashViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/splash/SplashViewModelTest.kt
@@ -5,9 +5,10 @@ import com.cramsan.edifikana.client.lib.features.EdifikanaWindowsEvent
 import com.cramsan.edifikana.client.lib.managers.AuthManager
 import com.cramsan.edifikana.client.lib.managers.PropertyManager
 import com.cramsan.framework.core.UnifiedDispatcherProvider
-import com.cramsan.framework.core.compose.ApplicationEventBus
+import com.cramsan.framework.core.compose.ApplicationEvent
+import com.cramsan.framework.core.compose.EventBus
 import com.cramsan.framework.core.compose.ViewModelDependencies
-import com.cramsan.framework.core.compose.WindowEventBus
+import com.cramsan.framework.core.compose.WindowEvent
 import com.cramsan.framework.logging.EventLogger
 import com.cramsan.framework.test.CollectorCoroutineExceptionHandler
 import com.cramsan.framework.test.TestBase
@@ -35,9 +36,9 @@ class SplashViewModelTest : TestBase() {
 
     private lateinit var exceptionHandler: CollectorCoroutineExceptionHandler
 
-    private lateinit var applicationEventReceiver: ApplicationEventBus
+    private lateinit var applicationEventReceiver: EventBus<ApplicationEvent>
 
-    private lateinit var windowEventBus: WindowEventBus
+    private lateinit var windowEventBus: EventBus<WindowEvent>
 
     @BeforeTest
     fun setupTest() {
@@ -66,7 +67,7 @@ class SplashViewModelTest : TestBase() {
         viewModel.onBackSelected()
 
         assertTrue(exceptionHandler.exceptions.isEmpty())
-        coVerify { windowEventBus.emit(EdifikanaWindowsEvent.NavigateBack) }
+        coVerify { windowEventBus.push(EdifikanaWindowsEvent.NavigateBack) }
     }
 
     @Test
@@ -78,7 +79,7 @@ class SplashViewModelTest : TestBase() {
 
         assertTrue(exceptionHandler.exceptions.isEmpty())
         coVerify { propertyManager.setActiveProperty(null) }
-        coVerify { windowEventBus.emit(
+        coVerify { windowEventBus.push(
             EdifikanaWindowsEvent.NavigateToActivity(
                 ActivityRouteDestination.AuthRouteDestination,
                 clearStack = true,
@@ -98,7 +99,7 @@ class SplashViewModelTest : TestBase() {
         assertTrue(exceptionHandler.exceptions.isEmpty())
         coVerify { propertyManager.setActiveProperty(null) }
         coVerify {
-            windowEventBus.emit(
+            windowEventBus.push(
                 EdifikanaWindowsEvent.NavigateToActivity(
                     ActivityRouteDestination.ManagementRouteDestination
                 )

--- a/framework/core-compose/src/commonMain/kotlin/com/cramsan/framework/core/compose/BaseViewModel.kt
+++ b/framework/core-compose/src/commonMain/kotlin/com/cramsan/framework/core/compose/BaseViewModel.kt
@@ -76,7 +76,8 @@ open class BaseViewModel<E : ViewModelEvent, UI : ViewModelUIState> (
     }
 
     protected suspend fun emitWindowEvent(event: WindowEvent) {
-        dependencies.windowEventReceiver.emit(event)
+        logD(tag, "Emitting window event: %s", event)
+        dependencies.windowEventReceiver.push(event)
     }
 
     protected suspend fun updateUiState(block: suspend (UI) -> UI) {

--- a/framework/core-compose/src/commonMain/kotlin/com/cramsan/framework/core/compose/EventReceiver.kt
+++ b/framework/core-compose/src/commonMain/kotlin/com/cramsan/framework/core/compose/EventReceiver.kt
@@ -14,7 +14,7 @@ interface EventReceiver<T> {
      *
      * @param event The event to be received.
      */
-    suspend fun emit(event: T)
+    suspend fun push(event: T)
 }
 
 /**
@@ -33,7 +33,7 @@ class InvalidEventBus<T> : EventReceiver<T>, EventEmitter<T> {
     override val events: Flow<T>
         get() = error("Do not use this receiver.")
 
-    override suspend fun emit(event: T) {
+    override suspend fun push(event: T) {
         error("Do not use this receiver.")
     }
 }
@@ -48,25 +48,7 @@ open class EventBus<T>(
     override val events: Flow<T>
         get() = sharedFlow.asSharedFlow()
 
-    override suspend fun emit(event: T) {
+    override suspend fun push(event: T) {
         sharedFlow.emit(event)
     }
 }
-
-/**
- * Application-level event bus for handling application-wide events.
- */
-class ApplicationEventBus(
-    sharedFlow: MutableSharedFlow<ApplicationEvent> = MutableSharedFlow(),
-) : EventBus<ApplicationEvent>(
-    sharedFlow,
-)
-
-/**
- * Window-level event bus for handling window-specific events.
- */
-class WindowEventBus(
-    sharedFlow: MutableSharedFlow<WindowEvent> = MutableSharedFlow(),
-) : EventBus<WindowEvent>(
-    sharedFlow,
-)

--- a/framework/core-compose/src/commonTest/kotlin/com/cramsan/framework/core/compose/BaseViewModelTest.kt
+++ b/framework/core-compose/src/commonTest/kotlin/com/cramsan/framework/core/compose/BaseViewModelTest.kt
@@ -33,17 +33,17 @@ class BaseViewModelTest : TestBase() {
 
     private lateinit var exceptionHandler: CollectorCoroutineExceptionHandler
 
-    private lateinit var applicationEventReceiver: ApplicationEventBus
+    private lateinit var applicationEventReceiver: EventBus<ApplicationEvent>
 
-    private lateinit var windowEventReceiver: WindowEventBus
+    private lateinit var windowEventReceiver: EventBus<WindowEvent>
 
     @BeforeTest
     fun setupTest() {
         exceptionHandler = CollectorCoroutineExceptionHandler()
         EventLogger.setInstance(PassthroughEventLogger(StdOutEventLoggerDelegate()))
         AssertUtil.setInstance(NoopAssertUtil())
-        applicationEventReceiver = ApplicationEventBus()
-        windowEventReceiver = WindowEventBus()
+        applicationEventReceiver = EventBus()
+        windowEventReceiver = EventBus()
         viewModel = TestableViewModel(
             dependencies = ViewModelDependencies(
                 appScope = testCoroutineScope,


### PR DESCRIPTION
Previously the navigation(and it's dependencies) was implemented as a singleton. In order to have multiple windows, I needed to break this assumption. 

To achieve this I used Koin scopes to define a scope for each "Window".  The term "Window" is a bit overloaded so in this context is refers to a single instance of the navigation controller, it's UI and it's ViewModels. 

Even though multi-windows is not a critical part of the application, it may be useful for cases like debugging and testing. In practice, both Android and Web will be implemented as a single-window application. The desktop is the only case in which multi windows may be benneficial. 