### PR TITLE
[EDIFIKANA] Updating the BE to have a new enrollUser API

### DIFF
--- a/edifikana/back-end/src/integTest/kotlin/com/cramsan/edifikana/server/core/repository/supabase/SupabaseUserDatabaseIntegrationTest.kt
+++ b/edifikana/back-end/src/integTest/kotlin/com/cramsan/edifikana/server/core/repository/supabase/SupabaseUserDatabaseIntegrationTest.kt
@@ -1,13 +1,17 @@
 package com.cramsan.edifikana.server.core.repository.supabase
 
+import com.cramsan.edifikana.lib.model.EnrollmentType
 import com.cramsan.edifikana.lib.model.UserId
 import com.cramsan.edifikana.lib.utils.ClientRequestExceptions
 import com.cramsan.edifikana.server.core.service.models.User
 import com.cramsan.edifikana.server.core.service.models.requests.CreateUserRequest
 import com.cramsan.edifikana.server.core.service.models.requests.DeleteUserRequest
+import com.cramsan.edifikana.server.core.service.models.requests.EnrollUserRequest
 import com.cramsan.edifikana.server.core.service.models.requests.GetUserRequest
 import com.cramsan.framework.utils.uuid.UUID
+import io.github.jan.supabase.auth.admin.AdminApi
 import org.junit.jupiter.api.assertInstanceOf
+import org.koin.test.inject
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -16,6 +20,8 @@ import kotlin.test.assertTrue
 class SupabaseUserDatabaseIntegrationTest : SupabaseIntegrationTest() {
 
     private lateinit var test_prefix: String
+
+    private val adminApi: AdminApi by inject()
 
     @BeforeTest
     fun setup() {
@@ -145,5 +151,32 @@ class SupabaseUserDatabaseIntegrationTest : SupabaseIntegrationTest() {
 
         // Assert
         assertTrue(deleteResult.isFailure || deleteResult.getOrNull() == false)
+    }
+
+    @Test
+    fun `enrollUser should return user on success`() = runBlockingTest {
+        // Arrange
+        val email = "enrollment-${test_prefix}-user@gmail.com"
+        val supabaseUser = adminApi.createUserWithEmail {
+            this.email = email
+            password = test_prefix
+            autoConfirm = true
+        }
+        val request = EnrollUserRequest(
+            userId = UserId(supabaseUser.id),
+            enrollmentIdentifier = email,
+            enrollmentType = EnrollmentType.EMAIL,
+        )
+
+        // Act
+        val result = userDatabase.enrollUser(request).registerUserForDeletion()
+        val user = result.getOrThrow()
+
+        // Assert
+        assertEquals(user.id, user.id)
+        assertEquals(user.email, email)
+        assertEquals(user.phoneNumber, "")
+        assertEquals(user.firstName, "")
+        assertEquals(user.lastName, "")
     }
 }

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/core/controller/ControllerUtils.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/core/controller/ControllerUtils.kt
@@ -70,7 +70,7 @@ suspend inline fun ApplicationCall.validateClientError(
     val exception = originalException as? ClientRequestExceptions
     if (exception == null) {
         // If the exception is not a ClientRequestException, we need to log it and return a 500 error.
-        logE(tag, "Unexpected failure when handing request", exception)
+        logE(tag, "Unexpected failure when handing request", originalException)
         respond(
             HttpStatusCode.InternalServerError,
             originalException?.localizedMessage.orEmpty(),

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/core/controller/UserController.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/core/controller/UserController.kt
@@ -5,6 +5,7 @@ import com.cramsan.edifikana.lib.USER_ID
 import com.cramsan.edifikana.lib.annotations.NetworkModel
 import com.cramsan.edifikana.lib.model.UserId
 import com.cramsan.edifikana.lib.model.network.CreateUserNetworkRequest
+import com.cramsan.edifikana.lib.model.network.EnrollUserNetworkRequest
 import com.cramsan.edifikana.lib.model.network.UpdatePasswordNetworkRequest
 import com.cramsan.edifikana.lib.model.network.UpdateUserNetworkRequest
 import com.cramsan.edifikana.lib.utils.requireAll
@@ -166,6 +167,26 @@ class UserController(
     }
 
     /**
+     * Handles the enrollment of a user. The [call] parameter is the request context.
+     * This method will enroll(or link) a user who may have already signed in with a different method.
+     */
+    @OptIn(NetworkModel::class)
+    suspend fun enrollUser(call: RoutingCall) = call.handleCall(TAG, "enrollUser", contextRetriever) {
+        val request = call.receive<EnrollUserNetworkRequest>()
+
+        val user = userService.enrollUser(
+            userId = UserId(request.userId),
+            enrollmentIdentifier = request.enrollmentIdentifier,
+            enrollmentType = request.enrollmentType,
+        ).requireSuccess().toUserNetworkResponse()
+
+        HttpResponse(
+            status = HttpStatusCode.OK,
+            body = user,
+        )
+    }
+
+    /**
      * Companion object.
      */
     companion object {
@@ -193,6 +214,9 @@ class UserController(
                 }
                 delete("{$USER_ID}") {
                     deleteUser(call)
+                }
+                post("enroll") {
+                    enrollUser(call)
                 }
             }
         }

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/core/repository/UserDatabase.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/core/repository/UserDatabase.kt
@@ -3,6 +3,7 @@ package com.cramsan.edifikana.server.core.repository
 import com.cramsan.edifikana.server.core.service.models.User
 import com.cramsan.edifikana.server.core.service.models.requests.CreateUserRequest
 import com.cramsan.edifikana.server.core.service.models.requests.DeleteUserRequest
+import com.cramsan.edifikana.server.core.service.models.requests.EnrollUserRequest
 import com.cramsan.edifikana.server.core.service.models.requests.GetUserRequest
 import com.cramsan.edifikana.server.core.service.models.requests.UpdatePasswordRequest
 import com.cramsan.edifikana.server.core.service.models.requests.UpdateUserRequest
@@ -51,8 +52,10 @@ interface UserDatabase {
     suspend fun updatePassword(request: UpdatePasswordRequest): Result<Boolean>
 
     /**
-     * Signs in a user with a magic link using the provided [email]. This method is used for passwordless
-     * sign in
+     * Enrolls a user for the given [request]. This is used for creating a new user account for users who may have
+     * previously signed in with a third-party provider.
+     *
+     * Returns the [Result] of the operation with the enrolled [User].
      */
-    suspend fun sendOtpCode(email: String): Result<Unit>
+    suspend fun enrollUser(request: EnrollUserRequest): Result<User>
 }

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/core/repository/dummy/DummyUserDatabase.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/core/repository/dummy/DummyUserDatabase.kt
@@ -4,6 +4,7 @@ import com.cramsan.edifikana.server.core.repository.UserDatabase
 import com.cramsan.edifikana.server.core.service.models.User
 import com.cramsan.edifikana.server.core.service.models.requests.CreateUserRequest
 import com.cramsan.edifikana.server.core.service.models.requests.DeleteUserRequest
+import com.cramsan.edifikana.server.core.service.models.requests.EnrollUserRequest
 import com.cramsan.edifikana.server.core.service.models.requests.GetUserRequest
 import com.cramsan.edifikana.server.core.service.models.requests.UpdatePasswordRequest
 import com.cramsan.edifikana.server.core.service.models.requests.UpdateUserRequest
@@ -43,9 +44,9 @@ class DummyUserDatabase : UserDatabase {
         return Result.success(true)
     }
 
-    override suspend fun sendOtpCode(email: String): Result<Unit> {
-        logD(TAG, "sendMagicLink to $email")
-        return Result.success(Unit)
+    override suspend fun enrollUser(request: EnrollUserRequest): Result<User> {
+        logD(TAG, "enrollUser")
+        return Result.success(USER_1)
     }
 
     companion object {

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/core/repository/supabase/SupabaseMappers.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/core/repository/supabase/SupabaseMappers.kt
@@ -1,5 +1,6 @@
 package com.cramsan.edifikana.server.core.repository.supabase
 
+import com.cramsan.edifikana.lib.model.EnrollmentType
 import com.cramsan.edifikana.lib.model.EventLogEntryId
 import com.cramsan.edifikana.lib.model.PropertyId
 import com.cramsan.edifikana.lib.model.StaffId
@@ -20,6 +21,8 @@ import com.cramsan.edifikana.server.core.service.models.requests.CreatePropertyR
 import com.cramsan.edifikana.server.core.service.models.requests.CreateStaffRequest
 import com.cramsan.edifikana.server.core.service.models.requests.CreateTimeCardEventRequest
 import com.cramsan.edifikana.server.core.service.models.requests.CreateUserRequest
+import com.cramsan.edifikana.server.core.service.models.requests.EnrollUserRequest
+import com.cramsan.framework.assertlib.assert
 import kotlinx.datetime.Instant
 
 // TODO Wire up the isVerified field to the rest of the system.
@@ -49,6 +52,27 @@ fun CreateUserRequest.toUserEntity(supabaseUserId: String): UserEntity.CreateUse
         phoneNumber = phoneNumber,
         firstName = firstName,
         lastName = lastName,
+    )
+}
+
+/**
+ * Maps an [EnrollUserRequest] to the [UserEntity.CreateUserEntity] model.
+ * This is a placeholder function and needs to be implemented based on the actual requirements.
+ */
+@OptIn(SupabaseModel::class)
+fun EnrollUserRequest.toUserEntity(supabaseUserId: String): UserEntity.CreateUserEntity {
+    assert(
+        enrollmentType == EnrollmentType.EMAIL,
+        TAG,
+        "Only email enrollment is supported in this workflow.",
+    )
+
+    return UserEntity.CreateUserEntity(
+        id = supabaseUserId,
+        email = this.enrollmentIdentifier,
+        phoneNumber = "",
+        firstName = "",
+        lastName = "",
     )
 }
 
@@ -169,3 +193,5 @@ fun EventLogEntryEntity.toEventLogEntry(): EventLogEntry {
         unit = this.unit,
     )
 }
+
+private const val TAG = "SupabaseMappers"

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/core/repository/supabase/SupabaseUserDatabase.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/core/repository/supabase/SupabaseUserDatabase.kt
@@ -1,11 +1,14 @@
 package com.cramsan.edifikana.server.core.repository.supabase
 
+import com.cramsan.edifikana.lib.model.EnrollmentType
+import com.cramsan.edifikana.lib.model.UserId
 import com.cramsan.edifikana.lib.utils.ClientRequestExceptions
 import com.cramsan.edifikana.server.core.repository.UserDatabase
 import com.cramsan.edifikana.server.core.repository.supabase.models.UserEntity
 import com.cramsan.edifikana.server.core.service.models.User
 import com.cramsan.edifikana.server.core.service.models.requests.CreateUserRequest
 import com.cramsan.edifikana.server.core.service.models.requests.DeleteUserRequest
+import com.cramsan.edifikana.server.core.service.models.requests.EnrollUserRequest
 import com.cramsan.edifikana.server.core.service.models.requests.GetUserRequest
 import com.cramsan.edifikana.server.core.service.models.requests.UpdatePasswordRequest
 import com.cramsan.edifikana.server.core.service.models.requests.UpdateUserRequest
@@ -19,6 +22,7 @@ import io.ktor.http.HttpStatusCode
 /**
  * Database for managing users.
  */
+@OptIn(SupabaseModel::class)
 class SupabaseUserDatabase(
     private val adminApi: AdminApi,
     private val postgrest: Postgrest,
@@ -27,7 +31,6 @@ class SupabaseUserDatabase(
     /**
      * Creates a new user for the given [request]. Returns the [Result] of the operation with the created [User].
      */
-    @OptIn(SupabaseModel::class)
     override suspend fun createUser(
         // TODO: Update section so we can actually create a user with an OTP signIn
         request: CreateUserRequest,
@@ -55,10 +58,7 @@ class SupabaseUserDatabase(
 
         // Create the user entity in our database
         val requestEntity: UserEntity.CreateUserEntity = request.toUserEntity(supabaseUser.id)
-        val createdUser = postgrest.from(UserEntity.COLLECTION).insert(requestEntity) {
-            select()
-        }.decodeSingle<UserEntity>()
-        logD(TAG, "User created userId: %s", createdUser.id)
+        val createdUser = createUserEntity(requestEntity)
 
         // Return the created user as a domain model
         createdUser.toUser(false)
@@ -67,22 +67,24 @@ class SupabaseUserDatabase(
     /**
      * Retrieves a user for the given [request]. Returns the [Result] of the operation with the fetched [User] if found.
      */
-    @OptIn(SupabaseModel::class)
     override suspend fun getUser(
         request: GetUserRequest,
     ): Result<User?> = runSuspendCatching(TAG) {
         logD(TAG, "Getting user: %s", request.id)
 
-        val userEntity = postgrest.from(UserEntity.COLLECTION).select {
-            filter {
-                eq("id", request.id.userId)
-            }
-        }.decodeSingleOrNull<UserEntity>()
+        val userEntity = getUserImpl(request.id)
 
         userEntity?.toUser()
     }
 
-    @OptIn(SupabaseModel::class)
+    private suspend fun getUserImpl(id: UserId): UserEntity? {
+        return postgrest.from(UserEntity.COLLECTION).select {
+            filter {
+                eq("id", id.userId)
+            }
+        }.decodeSingleOrNull<UserEntity>()
+    }
+
     override suspend fun getUsers(): Result<List<User>> = runSuspendCatching(TAG) {
         logD(TAG, "Getting all users")
 
@@ -92,7 +94,6 @@ class SupabaseUserDatabase(
     /**
      * Updates a user with the given [request]. Returns the [Result] of the operation with the updated [User].
      */
-    @OptIn(SupabaseModel::class)
     override suspend fun updateUser(
         request: UpdateUserRequest,
     ): Result<User> = runSuspendCatching(TAG) {
@@ -111,9 +112,9 @@ class SupabaseUserDatabase(
     }
 
     /**
-     * Deletes a user with the given [request]. Returns the [Result] of the operation with a [Boolean] indicating success.
+     * Deletes a user with the given [request].
+     * Returns the [Result] of the operation with a [Boolean] indicating success.
      */
-    @OptIn(SupabaseModel::class)
     override suspend fun deleteUser(
         request: DeleteUserRequest,
     ): Result<Boolean> = runSuspendCatching(TAG) {
@@ -139,13 +140,60 @@ class SupabaseUserDatabase(
         true
     }
 
-    /**
-     * Sends an OTP the provided [email]
-     */
-    override suspend fun sendOtpCode(email: String): Result<Unit> = runSuspendCatching(TAG) {
-        throw ClientRequestExceptions.InvalidRequestException(
-            message = "SupabaseUserDatabase does not support sending OTP codes.",
+    override suspend fun enrollUser(request: EnrollUserRequest): Result<User> = runSuspendCatching(TAG) {
+        logD(
+            TAG,
+            "Enrolling account for user: %s and enrollmentType",
+            request.enrollmentIdentifier,
+            request.enrollmentType,
         )
+
+        when (request.enrollmentType) {
+            EnrollmentType.EMAIL -> enrollEmailAccount(request)
+            EnrollmentType.PHONE -> TODO("Phone enrollment not implemented yet")
+        }
+    }
+
+    private suspend fun enrollEmailAccount(request: EnrollUserRequest): User {
+        // Lets ensure this email is not already registered
+        val existingUserByEmail = getUserByEmail(request.enrollmentIdentifier)
+        if (existingUserByEmail != null) {
+            throw ClientRequestExceptions.InvalidRequestException(
+                "User with email ${request.enrollmentIdentifier} already exists."
+            )
+        }
+
+        val existingUserByUserId = getUserImpl(request.userId)
+        if (existingUserByUserId != null) {
+            throw ClientRequestExceptions.InvalidRequestException(
+                "User with id ${request.userId} already exists."
+            )
+        }
+
+        // Lets create the user in our database. We are assuming the user has already created an account within supabase
+        val requestEntity: UserEntity.CreateUserEntity = request.toUserEntity(request.userId.userId)
+        val createdUser = createUserEntity(requestEntity)
+
+        return createdUser.toUser()
+    }
+
+    private suspend fun getUserByEmail(email: String): UserEntity? {
+        return postgrest.from(UserEntity.COLLECTION).select {
+            filter {
+                eq("email", email)
+            }
+        }.decodeSingleOrNull<UserEntity>()
+    }
+
+    private suspend fun createUserEntity(
+        userEntity: UserEntity.CreateUserEntity,
+    ): UserEntity {
+        // Create the user entity in our database
+        val createdUser = postgrest.from(UserEntity.COLLECTION).insert(userEntity) {
+            select()
+        }.decodeSingle<UserEntity>()
+        logD(TAG, "User created userId: %s", createdUser.id)
+        return createdUser
     }
 
     companion object {

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/core/service/UserService.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/core/service/UserService.kt
@@ -1,15 +1,16 @@
 package com.cramsan.edifikana.server.core.service
 
+import com.cramsan.edifikana.lib.model.EnrollmentType
 import com.cramsan.edifikana.lib.model.UserId
 import com.cramsan.edifikana.server.core.repository.UserDatabase
 import com.cramsan.edifikana.server.core.service.models.User
 import com.cramsan.edifikana.server.core.service.models.requests.CreateUserRequest
 import com.cramsan.edifikana.server.core.service.models.requests.DeleteUserRequest
+import com.cramsan.edifikana.server.core.service.models.requests.EnrollUserRequest
 import com.cramsan.edifikana.server.core.service.models.requests.GetUserRequest
 import com.cramsan.edifikana.server.core.service.models.requests.UpdatePasswordRequest
 import com.cramsan.edifikana.server.core.service.models.requests.UpdateUserRequest
 import com.cramsan.framework.logging.logD
-import com.cramsan.framework.logging.logI
 
 /**
  * Service for user operations.
@@ -21,6 +22,7 @@ class UserService(
     /**
      * Creates a user with the provided information.
      */
+    @Suppress("UnusedParameter")
     suspend fun createUser(
         email: String,
         phoneNumber: String,
@@ -39,14 +41,6 @@ class UserService(
                 lastName = lastName,
             ),
         )
-        // Send an OTP code if the user is created successfully and authorizeOtp is true
-        if (authorizeOtp && result.isSuccess) {
-            logI(TAG, "Sending OTP to user $email")
-            val otpResult = userDatabase.sendOtpCode(email)
-            if (!otpResult.isSuccess) {
-                logD(TAG, "Failed to send OTP to user $email: ${otpResult.exceptionOrNull()}")
-            }
-        }
 
         return result
     }
@@ -117,6 +111,27 @@ class UserService(
                 password = password,
             ),
         ).getOrThrow()
+    }
+
+    /**
+     * Enrolls an account for the user with the provided [userId] and [userIdentifier].
+     * This is used for creating a new user account for users who may have previously signed in with a
+     * third-party provider.
+     */
+    suspend fun enrollUser(
+        userId: UserId,
+        enrollmentIdentifier: String,
+        enrollmentType: EnrollmentType,
+    ): Result<User> {
+        logD(TAG, "enrollUser for user: %s", userId)
+
+        return userDatabase.enrollUser(
+            request = EnrollUserRequest(
+                userId = userId,
+                enrollmentIdentifier = enrollmentIdentifier,
+                enrollmentType = enrollmentType,
+            )
+        )
     }
 
     companion object {

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/core/service/models/requests/EnrollUserRequest.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/core/service/models/requests/EnrollUserRequest.kt
@@ -1,0 +1,17 @@
+package com.cramsan.edifikana.server.core.service.models.requests
+
+import com.cramsan.edifikana.lib.model.EnrollmentType
+import com.cramsan.edifikana.lib.model.UserId
+
+/**
+ * Request to enroll an account. This is used to associate a [userId] with an account identified by
+ * [enrollmentIdentifier] and of type [enrollmentType].
+ *
+ * This is typically used when a user wants to enroll an account into our system but the [userId] was generated
+ * externally.
+ */
+data class EnrollUserRequest(
+    val userId: UserId,
+    val enrollmentIdentifier: String,
+    val enrollmentType: EnrollmentType,
+)

--- a/edifikana/back-end/src/test/kotlin/com/cramsan/edifikana/server/core/controller/UserControllerTest.kt
+++ b/edifikana/back-end/src/test/kotlin/com/cramsan/edifikana/server/core/controller/UserControllerTest.kt
@@ -1,5 +1,6 @@
 package com.cramsan.edifikana.server.core.controller
 
+import com.cramsan.edifikana.lib.model.EnrollmentType
 import com.cramsan.edifikana.lib.model.UserId
 import com.cramsan.edifikana.lib.utils.ClientRequestExceptions
 import com.cramsan.edifikana.server.core.controller.auth.ClientContext
@@ -319,5 +320,46 @@ class UserControllerTest : TestBase(), KoinTest {
 
         // Assert
         assertEquals(HttpStatusCode.OK, response.status)
+    }
+
+    @Test
+    fun `test enrollUser`() = testEdifikanaApplication {
+        // Configure
+        val requestBody = readFileContent("requests/enroll_user_request.json")
+        val expectedResponse = readFileContent("requests/enroll_user_response.json")
+        val userService = get<UserService>()
+        val user = User(
+            id = UserId("user123"),
+            email = "test@gmail.com",
+            phoneNumber = "",
+            firstName = "",
+            lastName = "",
+            isVerified = true,
+        )
+        coEvery {
+            userService.enrollUser(
+                userId = UserId("user123"),
+                enrollmentIdentifier = "test@gmail.com",
+                enrollmentType = EnrollmentType.EMAIL,
+            )
+        }.answers {
+            Result.success(user)
+        }
+        val contextRetriever = get<ContextRetriever>()
+        coEvery {
+            contextRetriever.getContext(any())
+        }.answers {
+            ClientContext.UnauthenticatedClientContext
+        }
+
+        // Act
+        val response = client.post("user/enroll") {
+            setBody(requestBody)
+            contentType(ContentType.Application.Json)
+        }
+
+        // Assert
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals(expectedResponse, response.bodyAsText())
     }
 }

--- a/edifikana/back-end/src/test/kotlin/com/cramsan/edifikana/server/core/repository/supabase/SupabaseMappersTest.kt
+++ b/edifikana/back-end/src/test/kotlin/com/cramsan/edifikana/server/core/repository/supabase/SupabaseMappersTest.kt
@@ -1,0 +1,37 @@
+package com.cramsan.edifikana.server.core.repository.supabase
+
+import com.cramsan.edifikana.lib.model.EnrollmentType
+import com.cramsan.edifikana.lib.model.UserId
+import com.cramsan.edifikana.server.core.service.models.requests.EnrollUserRequest
+import com.cramsan.framework.assertlib.AssertUtil
+import com.cramsan.framework.assertlib.implementation.NoopAssertUtil
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(SupabaseModel::class)
+class SupabaseMappersTest {
+
+    @BeforeTest
+    fun setUp() {
+        AssertUtil.setInstance(NoopAssertUtil())
+    }
+
+    @Test
+    fun `toUserEntity should map EnrollUserRequest with EMAIL enrollment`() {
+        val request = EnrollUserRequest(
+            userId = UserId("user-123"),
+            enrollmentIdentifier = "test@example.com",
+            enrollmentType = EnrollmentType.EMAIL
+        )
+        val supabaseUserId = "supabase-uid-1"
+
+        val entity = request.toUserEntity(supabaseUserId)
+
+        assertEquals(supabaseUserId, entity.id)
+        assertEquals("test@example.com", entity.email)
+        assertEquals("", entity.phoneNumber)
+        assertEquals("", entity.firstName)
+        assertEquals("", entity.lastName)
+    }
+}

--- a/edifikana/back-end/src/test/kotlin/com/cramsan/edifikana/server/core/service/UserServiceTest.kt
+++ b/edifikana/back-end/src/test/kotlin/com/cramsan/edifikana/server/core/service/UserServiceTest.kt
@@ -1,5 +1,6 @@
 package com.cramsan.edifikana.server.core.service
 
+import com.cramsan.edifikana.lib.model.EnrollmentType
 import com.cramsan.edifikana.lib.model.UserId
 import com.cramsan.edifikana.server.core.controller.startTestKoin
 import com.cramsan.edifikana.server.core.repository.UserDatabase
@@ -50,7 +51,6 @@ class UserServiceTest {
         val lastName = "Doe"
         val user = mockk<User>()
         coEvery { userDatabase.createUser(any()) } returns Result.success(user)
-        coEvery { userDatabase.sendOtpCode(email) } returns Result.success(Unit)
 
         // Act
         val result = userService.createUser(email, phone, password, firstName, lastName, true)
@@ -58,24 +58,6 @@ class UserServiceTest {
         // Assert
         assertTrue(result.isSuccess)
         coVerify { userDatabase.createUser(match { it.email == email }) }
-        coVerify { userDatabase.sendOtpCode(email) }
-    }
-
-    /**
-     * Tests that createUser does not send an OTP if authorizeOtp is false.
-     */
-    @Test
-    fun `createUser should not send OTP if authorizeOtp is false`() = runTest {
-        // Arrange
-        val email = "test@example.com"
-        val user = mockk<User>()
-        coEvery { userDatabase.createUser(any()) } returns Result.success(user)
-
-        // Act
-        userService.createUser(email, "123", null, "A", "B", false)
-
-        // Assert
-        coVerify(exactly = 0) { userDatabase.sendOtpCode(email) }
     }
 
     /**
@@ -149,21 +131,27 @@ class UserServiceTest {
         coVerify { userDatabase.deleteUser(match { it.id == userId }) }
     }
 
-    /**
-     * Tests that updatePassword updates a user's password and returns the result.
-     */
     @Test
-    fun `updatePassword should update password and return result`() = runTest {
+    fun `enrollUser should enroll user and return result`() = runTest {
         // Arrange
         val userId = UserId("id")
-        val password = "newpass"
-        coEvery { userDatabase.updatePassword(any()) } returns Result.success(true)
-
+        val enrollmentIdentifier = "test@google.com"
+        val enrollmentType = EnrollmentType.EMAIL
+        val user = mockk<User>()
+        coEvery { userDatabase.enrollUser(any()) } returns Result.success(user)
         // Act
-        val result = userService.updatePassword(userId, password)
-
+        val result = userService.enrollUser(userId, enrollmentIdentifier, enrollmentType)
         // Assert
-        assertTrue(result)
-        coVerify { userDatabase.updatePassword(match { it.id == userId && it.password == password }) }
+        assertTrue(result.isSuccess)
+        assertEquals(user, result.getOrThrow())
+        coVerify {
+            userDatabase.enrollUser(
+                match {
+                    it.userId == userId &&
+                        it.enrollmentIdentifier == enrollmentIdentifier &&
+                        it.enrollmentType == enrollmentType
+                }
+            )
+        }
     }
 }

--- a/edifikana/back-end/src/test/resources/requests/enroll_user_request.json
+++ b/edifikana/back-end/src/test/resources/requests/enroll_user_request.json
@@ -1,0 +1,5 @@
+{
+    "user_id": "user123",
+    "enrollment_identifier": "test@gmail.com",
+    "enrollment_type": "EMAIL"
+}

--- a/edifikana/back-end/src/test/resources/requests/enroll_user_response.json
+++ b/edifikana/back-end/src/test/resources/requests/enroll_user_response.json
@@ -1,0 +1,8 @@
+{
+    "id": "user123",
+    "email": "test@gmail.com",
+    "phone_number": "",
+    "first_name": "",
+    "last_name": "",
+    "is_verified": true
+}

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/EnrollmentType.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/EnrollmentType.kt
@@ -1,0 +1,9 @@
+package com.cramsan.edifikana.lib.model
+
+/**
+ * The type of enrollment for the account.
+ */
+enum class EnrollmentType {
+    EMAIL,
+    PHONE,
+}

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/EnrollUserNetworkRequest.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/EnrollUserNetworkRequest.kt
@@ -1,0 +1,20 @@
+package com.cramsan.edifikana.lib.model.network
+
+import com.cramsan.edifikana.lib.annotations.NetworkModel
+import com.cramsan.edifikana.lib.model.EnrollmentType
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Request model for enrolling a user.
+ */
+@NetworkModel
+@Serializable
+data class EnrollUserNetworkRequest(
+    @SerialName("user_id")
+    val userId: String,
+    @SerialName("enrollment_identifier")
+    val enrollmentIdentifier: String,
+    @SerialName("enrollment_type")
+    val enrollmentType: EnrollmentType,
+)


### PR DESCRIPTION
To allow users to create an account by using an OTP method, the Supabase SDK only allows calls to be made from the client SDK. 
This means that clients will call supabase directly and the BE will need a way to determine when to create a new account and how to link it. For this I am creating a new `enrollUser` API.

The workflow will be like this:
- User selects creating account with OTP
- They input their email and request for an OTP
- The client code will use Supabase directly to request an OTP. This will also automatically create an account in Supabase(but not in our database).
- The client will call `enrollUser` with the ID of the newly created user as well as the email used to create the account. 
- The BE will create the account in our DB.
- The client will get their OTP code and proceed to sign in.

This PR contains unit tests and integrations test. 