### PR TITLE
[EDIFIKANA] Adding support for wasm preferences

### DIFF
--- a/edifikana/front-end/shared-app/src/wasmJsMain/kotlin/com/cramsan/edifikana/client/lib/di/FrameworkPlatformDelegatesModule.wasmJs.kt
+++ b/edifikana/front-end/shared-app/src/wasmJsMain/kotlin/com/cramsan/edifikana/client/lib/di/FrameworkPlatformDelegatesModule.wasmJs.kt
@@ -9,7 +9,7 @@ import com.cramsan.framework.logging.EventLoggerErrorCallbackDelegate
 import com.cramsan.framework.logging.implementation.NoopEventLoggerErrorCallbackDelegate
 import com.cramsan.framework.logging.implementation.StdOutEventLoggerDelegate
 import com.cramsan.framework.preferences.PreferencesDelegate
-import com.cramsan.framework.preferences.implementation.InMemoryPreferencesDelegate
+import com.cramsan.framework.preferences.implementation.BrowserLocalStoragePreferencesDelegate
 import com.cramsan.framework.thread.ThreadUtilDelegate
 import com.cramsan.framework.thread.implemantation.ThreadUtilDelegateNoop
 import org.koin.dsl.module
@@ -36,5 +36,5 @@ actual val FrameworkPlatformDelegatesModule = module {
         UIDispatcherProvider()
     }
 
-    single<PreferencesDelegate> { InMemoryPreferencesDelegate() }
+    single<PreferencesDelegate> { BrowserLocalStoragePreferencesDelegate() }
 }

--- a/framework/preferences/build.gradle.kts
+++ b/framework/preferences/build.gradle.kts
@@ -31,5 +31,10 @@ kotlin {
                 implementation(project(":framework:interfacelib-test"))
             }
         }
+        wasmJsMain {
+            dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-browser:_")
+            }
+        }
     }
 }

--- a/framework/preferences/src/wasmJsMain/kotlin/com/cramsan/framework/preferences/implementation/BrowserLocalStoragePreferencesDelegate.kt
+++ b/framework/preferences/src/wasmJsMain/kotlin/com/cramsan/framework/preferences/implementation/BrowserLocalStoragePreferencesDelegate.kt
@@ -1,0 +1,61 @@
+package com.cramsan.framework.preferences.implementation
+
+
+import com.cramsan.framework.logging.logW
+import com.cramsan.framework.preferences.PreferencesDelegate
+import org.w3c.dom.get
+import org.w3c.dom.set
+
+class BrowserLocalStoragePreferencesDelegate : PreferencesDelegate {
+
+    private val storage = kotlinx.browser.localStorage
+
+    override fun saveString(key: String, value: String?) {
+        if (value == null) {
+            storage.removeItem(key)
+        } else {
+            storage[key] = value
+        }
+    }
+
+    override fun loadString(key: String): String? {
+        return storage[key]
+    }
+
+    override fun saveInt(key: String, value: Int) {
+        storage[key] = value.toString()
+    }
+
+    override fun loadInt(key: String): Int? {
+        return storage[key]?.toIntOrNull()
+    }
+
+    override fun saveLong(key: String, value: Long) {
+        storage[key] = value.toString()
+    }
+
+    override fun loadLong(key: String): Long? {
+        return storage[key]?.toLongOrNull()
+    }
+
+    override fun saveBoolean(key: String, value: Boolean) {
+        storage[key] = value.toString()
+    }
+
+    override fun loadBoolean(key: String): Boolean? {
+        return storage[key]?.toBooleanStrictOrNull()
+    }
+
+    override fun remove(key: String) {
+        storage.removeItem(key)
+    }
+
+    override fun clear() {
+        logW(TAG, "clear() is not supported in BrowserLocalStoragePreferencesDelegate. " +
+                "Use remove() for individual keys.")
+    }
+
+    companion object {
+        private const val TAG = "BrowserLocalStoragePreferencesDelegate"
+    }
+}

--- a/versions.properties
+++ b/versions.properties
@@ -45,6 +45,8 @@ version.io.coil-kt.coil3..coil-network-ktor3=3.1.0
 
 version.io.github.sergio-sastre.ComposablePreviewScanner..jvm=0.6.1
 
+version.kotlinx.browser=0.3
+
 version.io.github.takahirom.roborazzi..roborazzi=1.44.0-alpha02
 
 version.io.github.takahirom.roborazzi..roborazzi-compose=1.44.0-alpha02


### PR DESCRIPTION
Previously the WASM target did not support storing preferences as there was not wasm implementation. This meant that we could not run the app since we needed to provide overrides for the endpoints.

This PR adds a preferences implementation that uses the wasm API for local storage. 

https://github.com/user-attachments/assets/3b4c338f-ae9c-44b3-9cbe-18bd0359369e

