### PR TITLE
[ALL] Fixing wasm targets

### DIFF
--- a/framework/assert/build.gradle.kts
+++ b/framework/assert/build.gradle.kts
@@ -19,6 +19,10 @@ kotlin {
         nodejs()
     }
 
+    wasmJs {
+        browser()
+    }
+
     sourceSets {
         commonMain {
             dependencies {

--- a/framework/core-compose/build.gradle.kts
+++ b/framework/core-compose/build.gradle.kts
@@ -10,7 +10,6 @@ apply(from = "$rootDir/gradle/kotlin-mpp-target-common-compose.gradle")
 apply(from = "$rootDir/gradle/kotlin-mpp-target-android-lib-compose.gradle")
 apply(from = "$rootDir/gradle/kotlin-mpp-target-jvm-compose.gradle")
 apply(from = "$rootDir/gradle/kotlin-mpp-target-ios.gradle")
-apply(from = "$rootDir/gradle/kotlin-mpp-target-js.gradle")
 apply(from = "$rootDir/gradle/kotlin-mpp-target-wasm.gradle")
 
 android {
@@ -22,10 +21,6 @@ android {
 }
 
 kotlin {
-    js {
-        nodejs()
-    }
-
     sourceSets {
         commonMain.dependencies {
             implementation(project(":framework:interfacelib"))

--- a/gradle/kotlin-mpp-target-wasm-compose-application.gradle
+++ b/gradle/kotlin-mpp-target-wasm-compose-application.gradle
@@ -21,3 +21,6 @@ compose.experimental {
 //     from(project(":alpaca-scheduler:front-end:appcore").file("src/commonMain/composeResources"))
 //     into("build/processedResources/wasmJs/main")
 // }
+
+// TODO: Enable this to build WASM distributables as part of the release process.
+// release.dependsOn('wasmJsBrowserDistribution')

--- a/gradle/kotlin-mpp-target-wasm.gradle
+++ b/gradle/kotlin-mpp-target-wasm.gradle
@@ -6,6 +6,9 @@ apply plugin: "org.jetbrains.kotlin.multiplatform"
 
 kotlin {
     wasmJs {
+        browser{
+
+        }
     }
 
     sourceSets {


### PR DESCRIPTION
Our WASM(web app) targets were broken due to an upgrade to Kotlin. We didn't catch this issue initially as the task to build the WASM distributables was not wired up as part of the releaseAll task. I tried adding this dependency but it cause some weird issues in the gradle configuration. In this PR I am fixing the WASM target and I have added a TODO for building the wasm distributables as part of the releaseAll. I also filed #195  to fix this problem in the near future. 