### PR TITLE
[ALL] Reverting log4j changes due to bad logging format

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -94,9 +94,9 @@ version.io.insert-koin=4.0.4
 
  version.koin=4.0.4
 
-version.org.apache.logging.log4j..log4j-slf4j-impl=2.25.0
+version.org.apache.logging.log4j..log4j-slf4j-impl=2.24.3
 
-version.org.apache.logging.log4j..log4j-slf4j2-impl=2.25.0
+version.org.apache.logging.log4j..log4j-slf4j2-impl=2.24.3
 
 version.org.jetbrains.compose.ui..ui-tooling-preview=1.8.2
 
@@ -105,9 +105,9 @@ version.app.cash.turbine.turbine=1.2.0
 
 version.robolectric=4.15.1
 
-version.org.apache.logging.log4j..log4j-core=2.25.0
+version.org.apache.logging.log4j..log4j-core=2.24.3
 
-version.org.apache.logging.log4j..log4j-api=2.25.0
+version.org.apache.logging.log4j..log4j-api=2.24.3
 
 version.mockk=1.14.4
 


### PR DESCRIPTION
There was a recent change that upgraded several packages. One of those packages was log4j to version `2.25.0`. In this version we were getting bad output when logging. Each line was being appended to the end of the last one instead of going to a new line. 

I have no fix for it for now so we are reverting to an old version. We can investigate this problem next time we try to perform package upgrades and we run a test pass. 