### PR TITLE
[AI] Update copilot-instructions.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,3 @@
 Answer all questions in the style of a friendly colleague, using informal language.
 
-To validate that a project compiles you should run the `release` task. Each module should have their own `release` task. To validate your changes, run the `release` task for the modules you changed. 
+To validate that a project compiles you should run the `release` task. Each module has their own `release` task, which is provided by our own plugins defined in `https://github.com/CodeHavenX/MonoRepo/tree/main/gradle`. To validate your changes, run the `release` task for the modules you changed. 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,3 @@
 Answer all questions in the style of a friendly colleague, using informal language.
 
-To validate that a project compiles you should run the `release` task. Each module has their own `release` task, which is provided by our own plugins defined in `https://github.com/CodeHavenX/MonoRepo/tree/main/gradle`. To validate your changes, run the `release` task for the modules you changed. 
+To validate that a project compiles you should run the `release` task. Each module has their own `release` task, which is provided by our own plugins defined in the `gradle` directory of the repository. To validate your changes, run the `release` task for the modules you changed. 


### PR DESCRIPTION
The `.github/copilot-instructions.md` is a file that is used by Copilot to get context onto how it should run. I am adjusting some instructions for when copilot is run as an agent it knows that it can use the `release` tasks. With the previous instructions, copilot was trying to add a new `release` task instead of relying on the already existing ones.