### PR TITLE
[EDIFIKANA] HOT FIX for having buildRelease only run on non-draft PRs

### DIFF
--- a/.github/workflows/buildRelease-pr.yml
+++ b/.github/workflows/buildRelease-pr.yml
@@ -10,6 +10,7 @@ name: Build All Targets Pull Request
 on:
   pull_request:
     branches: [ "main" ]
+    types: [review_requested, ready_for_review]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/buildRelease-pr.yml
+++ b/.github/workflows/buildRelease-pr.yml
@@ -10,7 +10,7 @@ name: Build All Targets Pull Request
 on:
   pull_request:
     branches: [ "main" ]
-    types: [ready_for_review]
+    types: [ready_for_review, synchronize]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/buildRelease-pr.yml
+++ b/.github/workflows/buildRelease-pr.yml
@@ -10,7 +10,7 @@ name: Build All Targets Pull Request
 on:
   pull_request:
     branches: [ "main" ]
-    types: [review_requested, ready_for_review]
+    types: [ready_for_review]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Updating our github action to only run on PRs that have a status review requested or ready for review to avoid unnecessary runs on draft PRs