### PR TITLE
[EDIFIKANA] Migrate responses to use value classes

### DIFF
--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/core/controller/EventLogController.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/core/controller/EventLogController.kt
@@ -3,8 +3,6 @@ package com.cramsan.edifikana.server.core.controller
 import com.cramsan.edifikana.lib.Routes
 import com.cramsan.edifikana.lib.Routes.EventLog.QueryParams.EVENT_LOG_ENTRY_ID
 import com.cramsan.edifikana.lib.model.EventLogEntryId
-import com.cramsan.edifikana.lib.model.PropertyId
-import com.cramsan.edifikana.lib.model.StaffId
 import com.cramsan.edifikana.lib.model.network.CreateEventLogEntryNetworkRequest
 import com.cramsan.edifikana.lib.model.network.UpdateEventLogEntryNetworkRequest
 import com.cramsan.edifikana.server.core.controller.authentication.ContextRetriever
@@ -42,9 +40,9 @@ class EventLogController(
         val createEventLogRequest = call.receive<CreateEventLogEntryNetworkRequest>()
 
         val newEventLog = eventLogService.createEventLogEntry(
-            staffId = createEventLogRequest.staffId?.let { StaffId(it) },
+            staffId = createEventLogRequest.staffId,
             fallbackStaffName = createEventLogRequest.fallbackStaffName,
-            propertyId = PropertyId(createEventLogRequest.propertyId),
+            propertyId = createEventLogRequest.propertyId,
             type = createEventLogRequest.type,
             fallbackEventType = createEventLogRequest.fallbackEventType,
             timestamp = Instant.fromEpochSeconds(createEventLogRequest.timestamp),

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/core/controller/NetworkMappers.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/core/controller/NetworkMappers.kt
@@ -47,12 +47,12 @@ fun User.toUserNetworkResponse(): UserNetworkResponse {
 @OptIn(NetworkModel::class)
 fun Staff.toStaffNetworkResponse(): StaffNetworkResponse {
     return StaffNetworkResponse(
-        id = id.staffId,
+        id = id,
         idType = idType,
         firstName = firstName,
         lastName = lastName,
         role = role,
-        propertyId = propertyId.propertyId,
+        propertyId = propertyId,
     )
 }
 
@@ -62,11 +62,11 @@ fun Staff.toStaffNetworkResponse(): StaffNetworkResponse {
 @OptIn(NetworkModel::class)
 fun EventLogEntry.toEventLogEntryNetworkResponse(): EventLogEntryNetworkResponse {
     return EventLogEntryNetworkResponse(
-        id = id.eventLogEntryId,
+        id = id,
         title = title,
-        staffId = staffId?.staffId,
+        staffId = staffId,
         fallbackStaffName = fallbackStaffName,
-        propertyId = propertyId.propertyId,
+        propertyId = propertyId,
         type = type,
         fallbackEventType = fallbackEventType,
         timestamp = timestamp.epochSeconds,
@@ -81,10 +81,10 @@ fun EventLogEntry.toEventLogEntryNetworkResponse(): EventLogEntryNetworkResponse
 @OptIn(NetworkModel::class)
 fun Property.toPropertyNetworkResponse(): PropertyNetworkResponse {
     return PropertyNetworkResponse(
-        id = id.propertyId,
+        id = id,
         name = name,
         address = address,
-        organizationId = organizationId.id,
+        organizationId = organizationId,
     )
 }
 
@@ -94,10 +94,10 @@ fun Property.toPropertyNetworkResponse(): PropertyNetworkResponse {
 @OptIn(NetworkModel::class)
 fun TimeCardEvent.toTimeCardEventNetworkResponse(): TimeCardEventNetworkResponse {
     return TimeCardEventNetworkResponse(
-        id = id.timeCardEventId,
-        staffId = staffId?.staffId,
+        id = id,
+        staffId = staffId,
         fallbackStaffName = fallbackStaffName,
-        propertyId = propertyId.propertyId,
+        propertyId = propertyId,
         type = type,
         imageUrl = imageUrl,
         timestamp = timestamp.epochSeconds,
@@ -110,7 +110,7 @@ fun TimeCardEvent.toTimeCardEventNetworkResponse(): TimeCardEventNetworkResponse
 @OptIn(NetworkModel::class)
 fun Asset.toAssetNetworkResponse(): AssetNetworkResponse {
     return AssetNetworkResponse(
-        id = id.assetId,
+        id = id,
         fileName = fileName,
         signedUrl = signedUrl,
     )
@@ -122,7 +122,7 @@ fun Asset.toAssetNetworkResponse(): AssetNetworkResponse {
 @OptIn(NetworkModel::class)
 fun Organization.toOrganizationNetworkResponse(): OrganizationNetworkResponse {
     return OrganizationNetworkResponse(
-        id = id.id,
+        id = id,
     )
 }
 
@@ -132,7 +132,7 @@ fun Organization.toOrganizationNetworkResponse(): OrganizationNetworkResponse {
 @OptIn(NetworkModel::class)
 fun Invite.toInviteNetworkResponse(): InviteNetworkResponse {
     return InviteNetworkResponse(
-        inviteId = inviteId.id,
+        inviteId = inviteId,
         email = email,
     )
 }

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/core/controller/PropertyController.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/core/controller/PropertyController.kt
@@ -2,7 +2,6 @@ package com.cramsan.edifikana.server.core.controller
 
 import com.cramsan.edifikana.lib.Routes
 import com.cramsan.edifikana.lib.Routes.Property.QueryParams.PROPERTY_ID
-import com.cramsan.edifikana.lib.model.OrganizationId
 import com.cramsan.edifikana.lib.model.PropertyId
 import com.cramsan.edifikana.lib.model.network.CreatePropertyNetworkRequest
 import com.cramsan.edifikana.lib.model.network.UpdatePropertyNetworkRequest
@@ -40,7 +39,7 @@ class PropertyController(
         val newProperty = propertyService.createProperty(
             createPropertyRequest.name,
             createPropertyRequest.address,
-            OrganizationId(createPropertyRequest.organizationId),
+            createPropertyRequest.organizationId,
             authenticatedContext,
         ).toPropertyNetworkResponse()
 

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/core/controller/StaffController.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/core/controller/StaffController.kt
@@ -2,7 +2,6 @@ package com.cramsan.edifikana.server.core.controller
 
 import com.cramsan.edifikana.lib.Routes
 import com.cramsan.edifikana.lib.Routes.Staff.QueryParams.STAFF_ID
-import com.cramsan.edifikana.lib.model.PropertyId
 import com.cramsan.edifikana.lib.model.StaffId
 import com.cramsan.edifikana.lib.model.network.CreateStaffNetworkRequest
 import com.cramsan.edifikana.lib.model.network.UpdateStaffNetworkRequest
@@ -45,7 +44,7 @@ class StaffController(
             firstName = createStaffRequest.firstName,
             lastName = createStaffRequest.lastName,
             role = createStaffRequest.role,
-            propertyId = PropertyId(createStaffRequest.propertyId),
+            propertyId = createStaffRequest.propertyId,
         ).toStaffNetworkResponse()
 
         HttpResponse(

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/core/controller/TimeCardController.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/core/controller/TimeCardController.kt
@@ -3,7 +3,6 @@ package com.cramsan.edifikana.server.core.controller
 import com.cramsan.edifikana.lib.Routes
 import com.cramsan.edifikana.lib.Routes.Staff.QueryParams.STAFF_ID
 import com.cramsan.edifikana.lib.Routes.TimeCard.QueryParams.TIMECARD_EVENT_ID
-import com.cramsan.edifikana.lib.model.PropertyId
 import com.cramsan.edifikana.lib.model.StaffId
 import com.cramsan.edifikana.lib.model.TimeCardEventId
 import com.cramsan.edifikana.lib.model.network.CreateTimeCardEventNetworkRequest
@@ -42,9 +41,9 @@ class TimeCardController(
         val createTimeCardRequest = call.receive<CreateTimeCardEventNetworkRequest>()
 
         val newTimeCard = timeCardService.createTimeCardEvent(
-            staffId = StaffId(createTimeCardRequest.staffId),
+            staffId = createTimeCardRequest.staffId,
             fallbackStaffName = createTimeCardRequest.fallbackStaffName,
-            propertyId = PropertyId(createTimeCardRequest.propertyId),
+            propertyId = createTimeCardRequest.propertyId,
             type = createTimeCardRequest.type,
             imageUrl = createTimeCardRequest.imageUrl,
             timestamp = Chronos.currentInstant(),

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/core/controller/UserController.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/core/controller/UserController.kt
@@ -88,10 +88,8 @@ class UserController(
     suspend fun getUsers(
         queryParams: GetAllUsersQueryParams,
     ): List<UserNetworkResponse> {
-        val orgId = requireNotBlank(queryParams.orgId, "An organization ID must be provided.")
-
         val users = userService.getUsers(
-            organizationId = OrganizationId(orgId)
+            organizationId = queryParams.orgId,
         ).getOrThrow().map { it.toUserNetworkResponse() }
 
         return users
@@ -147,11 +145,10 @@ class UserController(
     @OptIn(NetworkModel::class)
     suspend fun inviteUser(inviteRequest: InviteUserNetworkRequest) {
         val email = inviteRequest.email
-        val organizationId = OrganizationId(inviteRequest.organizationId)
 
         userService.inviteUser(
             email,
-            organizationId,
+            inviteRequest.organizationId,
         ).requireSuccess()
     }
 

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/service/impl/AuthServiceImpl.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/service/impl/AuthServiceImpl.kt
@@ -4,7 +4,6 @@ import com.cramsan.edifikana.api.UserApi
 import com.cramsan.edifikana.client.lib.models.Invite
 import com.cramsan.edifikana.client.lib.models.UserModel
 import com.cramsan.edifikana.client.lib.service.AuthService
-import com.cramsan.edifikana.lib.model.InviteId
 import com.cramsan.edifikana.lib.model.OrganizationId
 import com.cramsan.edifikana.lib.model.UserId
 import com.cramsan.edifikana.lib.model.network.CreateUserNetworkRequest
@@ -79,7 +78,7 @@ class AuthServiceImpl(
         organizationId: OrganizationId,
     ): Result<List<UserModel>> = runSuspendCatching(TAG) {
         val response = UserApi.getAllUsers
-            .buildRequest(GetAllUsersQueryParams(organizationId.id))
+            .buildRequest(GetAllUsersQueryParams(organizationId))
             .execute(http)
         val userModels = response.map { it.toUserModel() }
         userModels
@@ -230,7 +229,7 @@ class AuthServiceImpl(
         UserApi.inviteUser.buildRequest(
             InviteUserNetworkRequest(
                 email = email,
-                organizationId = organizationId.id
+                organizationId = organizationId
             ),
         ).execute(http)
     }
@@ -252,7 +251,7 @@ class AuthServiceImpl(
 @OptIn(NetworkModel::class)
 private fun InviteNetworkResponse.toInvite(): Invite {
     return Invite(
-        id = InviteId(this.inviteId),
+        id = this.inviteId,
         email = this.email,
     )
 }

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/service/impl/NetworkMappers.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/service/impl/NetworkMappers.kt
@@ -5,11 +5,6 @@ import com.cramsan.edifikana.client.lib.models.Organization
 import com.cramsan.edifikana.client.lib.models.StaffModel
 import com.cramsan.edifikana.client.lib.models.TimeCardRecordModel
 import com.cramsan.edifikana.client.lib.models.UserModel
-import com.cramsan.edifikana.lib.model.EventLogEntryId
-import com.cramsan.edifikana.lib.model.OrganizationId
-import com.cramsan.edifikana.lib.model.PropertyId
-import com.cramsan.edifikana.lib.model.StaffId
-import com.cramsan.edifikana.lib.model.TimeCardEventId
 import com.cramsan.edifikana.lib.model.UserId
 import com.cramsan.edifikana.lib.model.network.CreateEventLogEntryNetworkRequest
 import com.cramsan.edifikana.lib.model.network.CreateStaffNetworkRequest
@@ -29,10 +24,10 @@ import com.cramsan.framework.annotations.NetworkModel
 @OptIn(NetworkModel::class)
 fun EventLogEntryNetworkResponse.toEventLogRecordModel(): EventLogRecordModel {
     return EventLogRecordModel(
-        id = EventLogEntryId(id),
+        id = id,
         entityId = null,
-        staffPk = staffId?.let { it1 -> StaffId(it1) },
-        propertyId = PropertyId(propertyId),
+        staffPk = staffId,
+        propertyId = propertyId,
         timeRecorded = timestamp,
         unit = unit,
         eventType = type,
@@ -50,9 +45,9 @@ fun EventLogEntryNetworkResponse.toEventLogRecordModel(): EventLogRecordModel {
 @OptIn(NetworkModel::class)
 fun EventLogRecordModel.toCreateEventLogEntryNetworkRequest(): CreateEventLogEntryNetworkRequest {
     return CreateEventLogEntryNetworkRequest(
-        staffId = staffPk?.staffId,
+        staffId = staffPk,
         fallbackStaffName = fallbackStaffName,
-        propertyId = propertyId.propertyId,
+        propertyId = propertyId,
         type = eventType,
         fallbackEventType = fallbackEventType,
         timestamp = timeRecorded,
@@ -86,7 +81,7 @@ fun StaffModel.CreateStaffRequest.toCreateStaffNetworkRequest(): CreateStaffNetw
         firstName = firstName,
         lastName = lastName,
         role = role,
-        propertyId = propertyId.propertyId,
+        propertyId = propertyId,
     )
 }
 
@@ -110,7 +105,7 @@ fun StaffModel.UpdateStaffRequest.toUpdateStaffNetworkRequest(): UpdateStaffNetw
 @NetworkModel
 fun StaffNetworkResponse.toStaffModel(): StaffModel {
     return StaffModel(
-        id = StaffId(id),
+        id = id,
         firstName = firstName,
         lastName = lastName,
         role = role,
@@ -125,10 +120,10 @@ fun StaffNetworkResponse.toStaffModel(): StaffModel {
 @NetworkModel
 fun TimeCardRecordModel.toCreateTimeCardEventNetworkRequest(): CreateTimeCardEventNetworkRequest {
     return CreateTimeCardEventNetworkRequest(
-        staffId = staffPk.staffId,
+        staffId = staffPk,
         fallbackStaffName = "",
         type = eventType,
-        propertyId = propertyId.propertyId,
+        propertyId = propertyId,
         imageUrl = imageUrl,
     )
 }
@@ -139,10 +134,10 @@ fun TimeCardRecordModel.toCreateTimeCardEventNetworkRequest(): CreateTimeCardEve
 @NetworkModel
 fun TimeCardEventNetworkResponse.toTimeCardRecordModel(): TimeCardRecordModel {
     return TimeCardRecordModel(
-        id = TimeCardEventId(id),
+        id = id,
         entityId = null,
-        staffPk = StaffId(staffId ?: ""), // TODO: Fix this
-        propertyId = PropertyId(propertyId),
+        staffPk = staffId!!, // TODO: Fix this
+        propertyId = propertyId,
         eventType = type,
         eventTime = timestamp,
         imageUrl = imageUrl,
@@ -175,6 +170,6 @@ fun UserNetworkResponse.toUserModel(): UserModel {
 @OptIn(NetworkModel::class)
 fun OrganizationNetworkResponse.toOrganizationModel(): Organization {
     return Organization(
-        id = OrganizationId(id),
+        id = id,
     )
 }

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/service/impl/PropertyServiceImpl.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/service/impl/PropertyServiceImpl.kt
@@ -80,7 +80,7 @@ class PropertyServiceImpl(
                 CreatePropertyNetworkRequest(
                     name = propertyName,
                     address = address,
-                    organizationId = organizationId.id,
+                    organizationId = organizationId,
                 )
             )
             contentType(ContentType.Application.Json)
@@ -121,9 +121,9 @@ class PropertyServiceImpl(
 @NetworkModel
 private fun PropertyNetworkResponse.toPropertyModel(): PropertyModel {
     return PropertyModel(
-        id = PropertyId(id),
+        id = id,
         name = name,
         address = address.orEmpty(),
-        organizationId = OrganizationId(organizationId),
+        organizationId = organizationId,
     )
 }

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/service/impl/NetworkMappersTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/service/impl/NetworkMappersTest.kt
@@ -36,9 +36,9 @@ class NetworkMappersTest {
     fun `toTimeCardRecordModel maps all fields correctly`() {
         // Arrange
         val networkResponse = TimeCardEventNetworkResponse(
-            id = "event-123",
-            staffId = "staff-456",
-            propertyId = "property-789",
+            id = TimeCardEventId("event-123"),
+            staffId = StaffId("staff-456"),
+            propertyId = PropertyId("property-789"),
             type = TimeCardEventType.CLOCK_IN,
             timestamp = 1720000000L,
             imageUrl = "http://image.url",
@@ -97,9 +97,9 @@ class NetworkMappersTest {
     fun `toEventLogRecordModel maps all fields correctly`() {
         // Arrange
         val networkResponse = EventLogEntryNetworkResponse(
-            id = "eventlog-1",
-            staffId = "staff-1",
-            propertyId = "property-1",
+            id = EventLogEntryId("eventlog-1"),
+            staffId = StaffId("staff-1"),
+            propertyId = PropertyId("property-1"),
             timestamp = 123456789L,
             unit = "unit-1",
             type = EventLogEventType.INCIDENT,
@@ -151,9 +151,9 @@ class NetworkMappersTest {
         val request = model.toCreateEventLogEntryNetworkRequest()
 
         // Assert
-        assertEquals("staff-2", request.staffId)
+        assertEquals("staff-2", request.staffId?.staffId)
         assertEquals("fallbackName2", request.fallbackStaffName)
-        assertEquals("property-2", request.propertyId)
+        assertEquals("property-2", request.propertyId.propertyId)
         assertEquals(EventLogEventType.MAINTENANCE_SERVICE, request.type)
         assertEquals("fallbackType2", request.fallbackEventType)
         assertEquals(987654321L, request.timestamp)
@@ -218,7 +218,7 @@ class NetworkMappersTest {
         assertEquals("John", request.firstName)
         assertEquals("Doe", request.lastName)
         assertEquals(StaffRole.MANAGER, request.role)
-        assertEquals("property-4", request.propertyId)
+        assertEquals("property-4", request.propertyId.propertyId)
     }
 
     /**
@@ -229,12 +229,12 @@ class NetworkMappersTest {
     fun `toStaffModel maps all fields correctly`() {
         // Arrange
         val staffNetworkResponse = StaffNetworkResponse(
-            id = "staff-5",
+            id = StaffId("staff-5"),
             firstName = "Jane",
             lastName = "Smith",
             role = StaffRole.SECURITY,
             idType = IdType.DNI,
-            propertyId = "Cenit",
+            propertyId = PropertyId("Cenit"),
         )
 
         // Act
@@ -271,10 +271,10 @@ class NetworkMappersTest {
         val request = model.toCreateTimeCardEventNetworkRequest()
 
         // Assert
-        assertEquals("staff-6", request.staffId)
+        assertEquals("staff-6", request.staffId.staffId)
         assertEquals("", request.fallbackStaffName)
         assertEquals(TimeCardEventType.CLOCK_OUT, request.type)
-        assertEquals("property-6", request.propertyId)
+        assertEquals("property-6", request.propertyId.propertyId)
         assertEquals("http://image.url/6", request.imageUrl)
     }
 }

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/AssetId.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/AssetId.kt
@@ -1,10 +1,12 @@
 package com.cramsan.edifikana.lib.model
 
+import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmInline
 
 /**
  * Domain model representing a file ID.
  */
+@Serializable
 @JvmInline
 value class AssetId(val assetId: String) {
     override fun toString(): String = assetId

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/InviteId.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/InviteId.kt
@@ -1,11 +1,13 @@
 package com.cramsan.edifikana.lib.model
 
+import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmInline
 
 /**
  * Inline value class representing an Invite ID.
  * This is used to uniquely identify an invite in the system.
  */
+@Serializable
 @JvmInline
 value class InviteId(
     val id: String

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/OrganizationId.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/OrganizationId.kt
@@ -1,10 +1,12 @@
 package com.cramsan.edifikana.lib.model
 
+import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmInline
 
 /**
  * Domain model representing an organization ID.
  */
+@Serializable
 @JvmInline
 value class OrganizationId(val id: String) {
     override fun toString(): String = id

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/AssetNetworkResponse.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/AssetNetworkResponse.kt
@@ -1,5 +1,6 @@
 package com.cramsan.edifikana.lib.model.network
 
+import com.cramsan.edifikana.lib.model.AssetId
 import com.cramsan.framework.annotations.NetworkModel
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -12,7 +13,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class AssetNetworkResponse(
     @SerialName("id")
-    val id: String,
+    val id: AssetId,
     @SerialName("file_name")
     val fileName: String,
     @SerialName("signed_url")

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/CreateEventLogEntryNetworkRequest.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/CreateEventLogEntryNetworkRequest.kt
@@ -1,6 +1,8 @@
 package com.cramsan.edifikana.lib.model.network
 
 import com.cramsan.edifikana.lib.model.EventLogEventType
+import com.cramsan.edifikana.lib.model.PropertyId
+import com.cramsan.edifikana.lib.model.StaffId
 import com.cramsan.framework.annotations.NetworkModel
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -12,11 +14,11 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class CreateEventLogEntryNetworkRequest(
     @SerialName("staff_id")
-    val staffId: String?,
+    val staffId: StaffId?,
     @SerialName("fallback_staff_name")
     val fallbackStaffName: String?,
     @SerialName("property_id")
-    val propertyId: String,
+    val propertyId: PropertyId,
     val type: EventLogEventType,
     @SerialName("fallback_type")
     val fallbackEventType: String?,

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/CreatePropertyNetworkRequest.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/CreatePropertyNetworkRequest.kt
@@ -1,5 +1,6 @@
 package com.cramsan.edifikana.lib.model.network
 
+import com.cramsan.edifikana.lib.model.OrganizationId
 import com.cramsan.framework.annotations.NetworkModel
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -15,5 +16,5 @@ data class CreatePropertyNetworkRequest(
     @SerialName("address")
     val address: String,
     @SerialName("organization_id")
-    val organizationId: String,
+    val organizationId: OrganizationId,
 )

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/CreateStaffNetworkRequest.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/CreateStaffNetworkRequest.kt
@@ -1,6 +1,7 @@
 package com.cramsan.edifikana.lib.model.network
 
 import com.cramsan.edifikana.lib.model.IdType
+import com.cramsan.edifikana.lib.model.PropertyId
 import com.cramsan.edifikana.lib.model.StaffRole
 import com.cramsan.framework.annotations.NetworkModel
 import kotlinx.serialization.SerialName
@@ -20,5 +21,5 @@ data class CreateStaffNetworkRequest(
     val lastName: String,
     val role: StaffRole,
     @SerialName("property_id")
-    val propertyId: String,
+    val propertyId: PropertyId,
 )

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/CreateTimeCardEventNetworkRequest.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/CreateTimeCardEventNetworkRequest.kt
@@ -1,5 +1,7 @@
 package com.cramsan.edifikana.lib.model.network
 
+import com.cramsan.edifikana.lib.model.PropertyId
+import com.cramsan.edifikana.lib.model.StaffId
 import com.cramsan.edifikana.lib.model.TimeCardEventType
 import com.cramsan.framework.annotations.NetworkModel
 import kotlinx.serialization.SerialName
@@ -12,11 +14,11 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class CreateTimeCardEventNetworkRequest(
     @SerialName("staff_id")
-    val staffId: String,
+    val staffId: StaffId,
     @SerialName("fallback_staff_name")
     val fallbackStaffName: String?,
     @SerialName("property_id")
-    val propertyId: String,
+    val propertyId: PropertyId,
     val type: TimeCardEventType,
     @SerialName("image_url")
     val imageUrl: String?,

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/EventLogEntryNetworkResponse.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/EventLogEntryNetworkResponse.kt
@@ -1,6 +1,9 @@
 package com.cramsan.edifikana.lib.model.network
 
+import com.cramsan.edifikana.lib.model.EventLogEntryId
 import com.cramsan.edifikana.lib.model.EventLogEventType
+import com.cramsan.edifikana.lib.model.PropertyId
+import com.cramsan.edifikana.lib.model.StaffId
 import com.cramsan.framework.annotations.NetworkModel
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -11,13 +14,13 @@ import kotlinx.serialization.Serializable
 @NetworkModel
 @Serializable
 data class EventLogEntryNetworkResponse(
-    val id: String,
+    val id: EventLogEntryId,
     @SerialName("staff_id")
-    val staffId: String?,
+    val staffId: StaffId?,
     @SerialName("fallback_staff_name")
     val fallbackStaffName: String?,
     @SerialName("property_id")
-    val propertyId: String,
+    val propertyId: PropertyId,
     val type: EventLogEventType,
     @SerialName("fallback_type")
     val fallbackEventType: String?,

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/GetAllUsersQueryParams.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/GetAllUsersQueryParams.kt
@@ -1,5 +1,6 @@
 package com.cramsan.edifikana.lib.model.network
 
+import com.cramsan.edifikana.lib.model.OrganizationId
 import com.cramsan.framework.annotations.NetworkModel
 import kotlinx.serialization.Serializable
 
@@ -11,5 +12,5 @@ import kotlinx.serialization.Serializable
 @NetworkModel
 @Serializable
 data class GetAllUsersQueryParams(
-    val orgId: String? = null,
+    val orgId: OrganizationId,
 )

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/InviteNetworkResponse.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/InviteNetworkResponse.kt
@@ -1,5 +1,6 @@
 package com.cramsan.edifikana.lib.model.network
 
+import com.cramsan.edifikana.lib.model.InviteId
 import com.cramsan.framework.annotations.NetworkModel
 import kotlinx.serialization.Serializable
 
@@ -9,6 +10,6 @@ import kotlinx.serialization.Serializable
 @NetworkModel
 @Serializable
 data class InviteNetworkResponse(
-    val inviteId: String,
+    val inviteId: InviteId,
     val email: String,
 )

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/InviteUserNetworkRequest.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/InviteUserNetworkRequest.kt
@@ -1,5 +1,6 @@
 package com.cramsan.edifikana.lib.model.network
 
+import com.cramsan.edifikana.lib.model.OrganizationId
 import com.cramsan.framework.annotations.NetworkModel
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -13,5 +14,5 @@ data class InviteUserNetworkRequest(
     @SerialName("email")
     val email: String,
     @SerialName("organization_id")
-    val organizationId: String,
+    val organizationId: OrganizationId,
 )

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/OrganizationNetworkResponse.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/OrganizationNetworkResponse.kt
@@ -1,5 +1,6 @@
 package com.cramsan.edifikana.lib.model.network
 
+import com.cramsan.edifikana.lib.model.OrganizationId
 import com.cramsan.framework.annotations.NetworkModel
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -11,5 +12,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class OrganizationNetworkResponse(
     @SerialName("id")
-    val id: String,
+    val id: OrganizationId,
 )

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/PropertyNetworkResponse.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/PropertyNetworkResponse.kt
@@ -1,5 +1,7 @@
 package com.cramsan.edifikana.lib.model.network
 
+import com.cramsan.edifikana.lib.model.OrganizationId
+import com.cramsan.edifikana.lib.model.PropertyId
 import com.cramsan.framework.annotations.NetworkModel
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -11,11 +13,11 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class PropertyNetworkResponse(
     @SerialName("id")
-    val id: String,
+    val id: PropertyId,
     @SerialName("name")
     val name: String,
     @SerialName("address")
     val address: String? = null,
     @SerialName("organization_id")
-    val organizationId: String,
+    val organizationId: OrganizationId,
 )

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/StaffNetworkResponse.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/StaffNetworkResponse.kt
@@ -1,6 +1,8 @@
 package com.cramsan.edifikana.lib.model.network
 
 import com.cramsan.edifikana.lib.model.IdType
+import com.cramsan.edifikana.lib.model.PropertyId
+import com.cramsan.edifikana.lib.model.StaffId
 import com.cramsan.edifikana.lib.model.StaffRole
 import com.cramsan.framework.annotations.NetworkModel
 import kotlinx.serialization.SerialName
@@ -12,7 +14,7 @@ import kotlinx.serialization.Serializable
 @NetworkModel
 @Serializable
 data class StaffNetworkResponse(
-    val id: String,
+    val id: StaffId,
     @SerialName("id_type")
     val idType: IdType,
     @SerialName("first_name")
@@ -21,5 +23,5 @@ data class StaffNetworkResponse(
     val lastName: String,
     val role: StaffRole,
     @SerialName("property_id")
-    val propertyId: String,
+    val propertyId: PropertyId,
 )

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/TimeCardEventNetworkResponse.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/TimeCardEventNetworkResponse.kt
@@ -1,5 +1,8 @@
 package com.cramsan.edifikana.lib.model.network
 
+import com.cramsan.edifikana.lib.model.PropertyId
+import com.cramsan.edifikana.lib.model.StaffId
+import com.cramsan.edifikana.lib.model.TimeCardEventId
 import com.cramsan.edifikana.lib.model.TimeCardEventType
 import com.cramsan.framework.annotations.NetworkModel
 import kotlinx.serialization.SerialName
@@ -12,13 +15,13 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class TimeCardEventNetworkResponse(
     @SerialName("id")
-    val id: String,
+    val id: TimeCardEventId,
     @SerialName("staff_id")
-    val staffId: String?,
+    val staffId: StaffId?,
     @SerialName("fallback_staff_name")
     val fallbackStaffName: String?,
     @SerialName("property_id")
-    val propertyId: String,
+    val propertyId: PropertyId,
     val type: TimeCardEventType,
     @SerialName("image_url")
     val imageUrl: String?,


### PR DESCRIPTION
This change should help us by reducing the amount of boilerplate code we need to write. In this PR I am using the data classes directly from the serialized request/responses.