### PR TITLE
[DEPS] Upgrading to kotlin 2.3.0 and detekt 2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,51 @@
+# EditorConfig - https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{kt,kts}]
+# IntelliJ IDEA code style
+ij_kotlin_code_style_defaults = KOTLIN_OFFICIAL
+
+# ktlint code style - must be set explicitly for ktlint to use these defaults
+ktlint_code_style = ktlint_official
+
+#  Disable wildcard imports entirely
+ij_kotlin_name_count_to_use_star_import = 2147483647
+ij_kotlin_name_count_to_use_star_import_for_members = 2147483647
+ij_kotlin_packages_to_use_import_on_demand = unset
+
+# Max line length before wrapping
+max_line_length = 120
+
+# Force function signatures to multiline when parameter count >= 2
+# Functions with 2+ parameters will have each parameter on its own line
+ktlint_function_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than = 2
+
+# Force class signatures to multiline when parameter count >= 1
+ktlint_class_signature_rule_force_multiline_when_parameter_count_greater_or_equal_than = 1
+
+# Control function body expression wrapping
+# Options: default, multiline, always
+ktlint_function_signature_body_expression_wrapping = default
+
+# Force chained method calls to multiline when chain operator count >= 4
+ktlint_chain_method_rule_force_multiline_when_chain_operator_count_greater_or_equal_than = 4
+
+# Argument list wrapping - ensures arguments in function calls wrap properly
+ktlint_argument_list_wrapping_max_line_length = 120
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.{json,json5}]
+indent_size = 2

--- a/architecture/front-end-architecture/build.gradle.kts
+++ b/architecture/front-end-architecture/build.gradle.kts
@@ -1,6 +1,5 @@
 @file:OptIn(ExperimentalWasmDsl::class)
 
-import io.gitlab.arturbosch.detekt.Detekt
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 
 plugins {
@@ -160,32 +159,7 @@ room {
     schemaDirectory("$projectDir/schemas")
 }
 
-// We need to manually create a detekt task for the NoDB source-set since the detekt plugin only auto-generates tasks
-// for the default targets. This behaviour is not very well documented. I am making this conclusion based on this page:
-// https://detekt.dev/docs/gettingstarted/gradle#available-plugin-tasks
-tasks.register<Detekt>("detektMetadataNoDB") {
-    // This task is configured following the global implementation found here:
-    // $rootDir/gradle/detekt.gradle
-    description = "Run detekt on the noDB source-set."
-
-    setSource(files("src/noDB/"))
-
-    autoCorrect = true
-
-    val localConfigFile = file("$projectDir/config/detekt-config.yml")
-    val globalConfigFile = file("$rootDir/config/detekt-config.yml")
-    val existingFiles = listOf(globalConfigFile, localConfigFile)
-        .filter { it.exists() }
-        .map { it.path }
-    config = files(existingFiles)
-
-    val baselineFile = file("$projectDir/config/detekt-baseline.xml")
-    if (baselineFile.exists()) {
-        baseline = baselineFile
-    }
-}
-
 tasks.getByName("release") {
-    dependsOn("detektMetadataLocalDB")
-    dependsOn("detektMetadataNoDB")
+    dependsOn("detektLocalDBSourceSet")
+    dependsOn("detektNoDBSourceSet")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     kotlin("plugin.serialization") apply false
     id("androidx.navigation.safeargs.kotlin") apply false
     id("com.squareup.sqldelight") apply false
-    id("io.gitlab.arturbosch.detekt") apply false
+    id("dev.detekt") apply false
     id("io.github.takahirom.roborazzi") apply false
 }
 

--- a/config/detekt-config.yml
+++ b/config/detekt-config.yml
@@ -4,8 +4,8 @@ complexity:
   LongParameterList:
     ignoreAnnotated: [ 'Composable' ]
     active: true
-    functionThreshold: 12
-    constructorThreshold: 12
+    allowedFunctionParameters: 12
+    allowedConstructorParameters: 12
     ignoreDefaultParameters: false
     ignoreDataClasses: true
     ignoreAnnotatedParameter: []
@@ -59,8 +59,15 @@ style:
     max: 8
   MaxLineLength:
     active: false
-  UnusedPrivateMember:
+  # UnusedPrivateMember was split into UnusedPrivateClass, UnusedPrivateFunction, UnusedPrivateProperty in detekt 2.0
+  UnusedPrivateClass:
+    active: true
+  UnusedPrivateFunction:
     ignoreAnnotated: [ 'Preview' ]
+    active: true
+  UnusedPrivateProperty:
+    ignoreAnnotated: [ 'Preview' ]
+    active: true
 
 coroutines:
   excludes:
@@ -68,17 +75,15 @@ coroutines:
   InjectDispatcher:
     ignoreAnnotated: [ 'BackgroundDispatcher', 'UIThreadDispatcher' ]
 
-formatting:
-  active: true
-  android: true
-  autoCorrect: true
+# ktlint rules (detekt 2.0 uses ktlint-wrapper with different config schema)
+ktlint:
+  active: false
   excludes:
     - '**/build/generated/**'
-  MaximumLineLength:
-    active: true
-    ignoreAnnotated: [ 'Test', 'Preview' ]
-    autoCorrect: true
-    maxLineLength: 120
+  ClassSignature:
+    active: false
+  FunctionSignature:
+    active: false
 
 empty-blocks:
   excludes:

--- a/edifikana/front-end/shared-app/build.gradle.kts
+++ b/edifikana/front-end/shared-app/build.gradle.kts
@@ -1,6 +1,5 @@
 @file:OptIn(ExperimentalWasmDsl::class)
 
-import io.gitlab.arturbosch.detekt.Detekt
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 
 plugins {
@@ -193,34 +192,9 @@ room {
     schemaDirectory("$projectDir/schemas")
 }
 
-// We need to manually create a detekt task for the NoDB source-set since the detekt plugin only auto-generates tasks
-// for the default targets. This behaviour is not very well documented. I am making this conclusion based on this page:
-// https://detekt.dev/docs/gettingstarted/gradle#available-plugin-tasks
-tasks.register<Detekt>("detektMetadataNoDB") {
-    // This task is configured following the global implementation found here:
-    // $rootDir/gradle/detekt.gradle
-    description = "Run detekt on the noDB source-set."
-
-    setSource(files("src/noDB/"))
-
-    autoCorrect = true
-
-    val localConfigFile = file("$projectDir/config/detekt-config.yml")
-    val globalConfigFile = file("$rootDir/config/detekt-config.yml")
-    val existingFiles = listOf(globalConfigFile, localConfigFile)
-        .filter { it.exists() }
-        .map { it.path }
-    config = files(existingFiles)
-
-    val baselineFile = file("$projectDir/config/detekt-baseline.xml")
-    if (baselineFile.exists()) {
-        baseline = baselineFile
-    }
-}
-
 tasks.getByName("release") {
-    dependsOn("detektMetadataLocalDB")
-    dependsOn("detektMetadataNoDB")
+    dependsOn("detektLocalDBSourceSet")
+    dependsOn("detektNoDBSourceSet")
 }
 
 roborazzi {

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/service/impl/AuthServiceImplTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/service/impl/AuthServiceImplTest.kt
@@ -393,7 +393,7 @@ class AuthServiceImplTest {
             lastName = "Doe",
             authMetadata = null,
         )
-        coEvery { auth.verifyEmailOtp(OtpType.Email.EMAIL, email, hashToken) } just Runs
+        coEvery { auth.verifyEmailOtp(OtpType.Email.EMAIL, email, hashToken) } returns mockk()
         coEvery { auth.currentUserOrNull() } returns userInfo
         ktorTestEngine.configure {
             coEvery { produceResponse(any()) } returns MockResponseData.Success(
@@ -424,7 +424,7 @@ class AuthServiceImplTest {
             lastName = "Smith",
             authMetadata = null,
         )
-        coEvery { auth.verifyEmailOtp(OtpType.Email.EMAIL, email, hashToken) } just Runs
+        coEvery { auth.verifyEmailOtp(OtpType.Email.EMAIL, email, hashToken) } returns mockk()
         coEvery { auth.currentUserOrNull() } returns userInfo
         ktorTestEngine.configure {
             coEvery { produceResponse(any()) } returns MockResponseData.Success(

--- a/gradle/detekt.gradle
+++ b/gradle/detekt.gradle
@@ -1,8 +1,8 @@
 import static de.fayard.refreshVersions.core.Versions.versionFor
 
-apply plugin: "io.gitlab.arturbosch.detekt"
+apply plugin: "dev.detekt"
 
-def detektFormattingVersion = versionFor(project, "version.io.gitlab.arturbosch.detekt..detekt-formatting")
+def detektKtlintWrapperVersion = versionFor(project, "version.dev.detekt..detekt-rules-ktlint-wrapper")
 
 
 /**
@@ -33,6 +33,6 @@ detekt {
     }
 
     dependencies {
-        detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:$detektFormattingVersion")
+        detektPlugins("dev.detekt:detekt-rules-ktlint-wrapper:$detektKtlintWrapperVersion")
     }
 }

--- a/gradle/kotlin-mpp-target-android-app.gradle
+++ b/gradle/kotlin-mpp-target-android-app.gradle
@@ -142,8 +142,8 @@ tasks.register("releaseAndroid") {
 
     dependsOn 'build' // Assembles and test this project
     dependsOn 'bundle' // Assembles and test this project
-    dependsOn 'detektMetadataMain' // Run the code analyzer on the common-code source set
-    dependsOn 'detektAndroidPreprodDebug' // Run the code analyzer
+    dependsOn 'detektCommonMainSourceSet' // Run the code analyzer on the common-code source set
+    dependsOn 'detektAndroidDebugSourceSet' // Run the code analyzer
     // TODO: Identify the right task to run tests
 }
 

--- a/gradle/kotlin-mpp-target-android-lib.gradle
+++ b/gradle/kotlin-mpp-target-android-lib.gradle
@@ -77,8 +77,8 @@ tasks.register("releaseAndroid") {
     description = 'Run all the steps to build a releaseAndroid artifact'
     dependsOn 'assembleDebug'
     dependsOn 'assembleRelease'
-    dependsOn 'detektMetadataMain' // Run the code analyzer on the common-code source set
-    dependsOn 'detektAndroidDebug' // Run the code analyzer
+    dependsOn 'detektCommonMainSourceSet' // Run the code analyzer on the common-code source set
+    dependsOn 'detektAndroidDebugSourceSet' // Run the code analyzer
     dependsOn 'testDebugUnitTest'
     dependsOn 'testReleaseUnitTest'
 }

--- a/gradle/kotlin-mpp-target-ios.gradle
+++ b/gradle/kotlin-mpp-target-ios.gradle
@@ -22,8 +22,8 @@ tasks.register("releaseIos") {
     group = 'release'
     description = 'Run all the steps to build a releaseIos artifact'
     dependsOn 'compileKotlinIosSimulatorArm64'
-    dependsOn 'detektMetadataMain' // Run the code analyzer on the common-code source set
-    dependsOn 'detektIosSimulatorArm64Main' // Run the code analyzer
+    dependsOn 'detektCommonMainSourceSet' // Run the code analyzer on the common-code source set
+    dependsOn 'detektIosSimulatorArm64MainSourceSet' // Run the code analyzer
     dependsOn 'iosSimulatorArm64Test'
 }
 

--- a/gradle/kotlin-mpp-target-js.gradle
+++ b/gradle/kotlin-mpp-target-js.gradle
@@ -26,8 +26,8 @@ tasks.register("releaseJs") {
     group = 'release'
     description = 'Run all the steps to build a Js artifact'
     dependsOn 'compileKotlinJs'
-    dependsOn 'detektMetadataMain' // Run the code analyzer on the common-code source set
-    dependsOn 'detektJsMain' // Run the code analyzer
+    dependsOn 'detektCommonMainSourceSet' // Run the code analyzer on the common-code source set
+    dependsOn 'detektJsMainSourceSet' // Run the code analyzer
     dependsOn 'jsTest'
 }
 

--- a/gradle/kotlin-mpp-target-jvm.gradle
+++ b/gradle/kotlin-mpp-target-jvm.gradle
@@ -51,8 +51,8 @@ tasks.register("releaseJvm") {
     group = 'release'
     description = 'Run all the steps to build a releaseJvm artifact'
     dependsOn 'compileKotlinJvm'
-    dependsOn 'detektMetadataMain' // Run the code analyzer on the common-code source set
-    dependsOn 'detektJvmMain' // Run the code analyzer
+    dependsOn 'detektCommonMainSourceSet' // Run the code analyzer on the common-code source set
+    dependsOn 'detektJvmMainSourceSet' // Run the code analyzer
     dependsOn 'jvmTest'
 }
 

--- a/gradle/kotlin-mpp-target-wasm.gradle
+++ b/gradle/kotlin-mpp-target-wasm.gradle
@@ -24,8 +24,8 @@ tasks.register("releaseWasm") {
     group = 'release'
     description = 'Run all the steps to build a releaseWasn artifact'
     dependsOn 'wasmJsMainClasses'
-    dependsOn 'detektMetadataMain' // Run the code analyzer on the common-code source set
-    dependsOn 'detektWasmJsMain' // Run the code analyzer
+    dependsOn 'detektCommonMainSourceSet' // Run the code analyzer on the common-code source set
+    dependsOn 'detektWasmJsMainSourceSet' // Run the code analyzer
     // TODO: Identify the right target to run tests
 }
 

--- a/templatereplaceme/front-end/shared-app/build.gradle.kts
+++ b/templatereplaceme/front-end/shared-app/build.gradle.kts
@@ -1,6 +1,5 @@
 @file:OptIn(ExperimentalWasmDsl::class)
 
-import io.gitlab.arturbosch.detekt.Detekt
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 
 plugins {
@@ -180,34 +179,9 @@ room {
     schemaDirectory("$projectDir/schemas")
 }
 
-// We need to manually create a detekt task for the NoDB source-set since the detekt plugin only auto-generates tasks
-// for the default targets. This behaviour is not very well documented. I am making this conclusion based on this page:
-// https://detekt.dev/docs/gettingstarted/gradle#available-plugin-tasks
-tasks.register<Detekt>("detektMetadataNoDB") {
-    // This task is configured following the global implementation found here:
-    // $rootDir/gradle/detekt.gradle
-    description = "Run detekt on the noDB source-set."
-
-    setSource(files("src/noDB/"))
-
-    autoCorrect = true
-
-    val localConfigFile = file("$projectDir/config/detekt-config.yml")
-    val globalConfigFile = file("$rootDir/config/detekt-config.yml")
-    val existingFiles = listOf(globalConfigFile, localConfigFile)
-        .filter { it.exists() }
-        .map { it.path }
-    config = files(existingFiles)
-
-    val baselineFile = file("$projectDir/config/detekt-baseline.xml")
-    if (baselineFile.exists()) {
-        baseline = baselineFile
-    }
-}
-
 tasks.getByName("release") {
-    dependsOn("detektMetadataLocalDB")
-    dependsOn("detektMetadataNoDB")
+    dependsOn("detektLocalDBSourceSet")
+    dependsOn("detektNoDBSourceSet")
 }
 
 roborazzi {

--- a/versions.properties
+++ b/versions.properties
@@ -20,13 +20,7 @@ version.androidx.camera=1.5.3
 plugin.androidx.room=2.8.4
 
 # KSP version must match Kotlin version. Upgrade together with Kotlin.
-plugin.com.google.devtools.ksp=2.2.21-2.0.4
-##                 # available=2.3.0
-##                 # available=2.3.1
-##                 # available=2.3.2
-##                 # available=2.3.3
-##                 # available=2.3.4
-##                 # available=2.3.5
+plugin.com.google.devtools.ksp=2.3.0
 
 version.app.cash.turbine=1.2.1
 
@@ -34,26 +28,17 @@ version.com.microsoft.appcenter..appcenter-analytics=5.0.6
 
 version.com.microsoft.appcenter..appcenter-crashes=5.0.6
 
-# Supabase 3.3.0 upgrade failed with WasmJS internal compiler error (2026-01-31).
-# Error: compileKotlinWasmJs - Internal compiler error
-# Likely requires Kotlin upgrade to 2.3.0 first. Retry after Kotlin upgrade.
-version.io.github.jan-tennert.supabase..auth-kt=3.2.4
-##                                  # available=3.3.0
+version.io.github.jan-tennert.supabase..auth-kt=3.3.0
 
-version.io.github.jan-tennert.supabase..coil3-integration=3.2.4
-##                                            # available=3.3.0
+version.io.github.jan-tennert.supabase..coil3-integration=3.3.0
 
-version.io.github.jan-tennert.supabase..storage-kt=3.2.4
-##                                     # available=3.3.0
+version.io.github.jan-tennert.supabase..storage-kt=3.3.0
 
-version.io.github.jan-tennert.supabase..postgrest-kt=3.2.4
-##                                       # available=3.3.0
+version.io.github.jan-tennert.supabase..postgrest-kt=3.3.0
 
-version.io.github.jan-tennert.supabase..compose-auth-ui=3.2.4
-##                                          # available=3.3.0
+version.io.github.jan-tennert.supabase..compose-auth-ui=3.3.0
 
-version.io.github.jan-tennert.supabase..compose-auth=3.2.4
-##                                       # available=3.3.0
+version.io.github.jan-tennert.supabase..compose-auth=3.3.0
 
 version.io.coil-kt.coil3..coil-compose=3.3.0
 
@@ -93,7 +78,10 @@ version.androidx.exifinterface=1.4.2
 plugin.io.ktor.plugin=3.3.3
 ##        # available=3.4.0
 
-plugin.io.gitlab.arturbosch.detekt=1.23.8
+# Detekt 2.0.0-alpha.2 required for Kotlin 2.3.0 compatibility (new plugin ID: dev.detekt)
+plugin.dev.detekt=2.0.0-alpha.2
+
+version.dev.detekt..detekt-rules-ktlint-wrapper=2.0.0-alpha.2
 
 plugin.io.github.takahirom.roborazzi=1.57.0
 
@@ -155,8 +143,7 @@ version.kotlinx.serialization=1.9.0
 
 version.kotlinx.coroutines=1.10.2
 
-version.kotlin=2.2.21
-## # available=2.3.0
+version.kotlin=2.3.0
 
 version.junit.jupiter=5.14.2
 ##        # available=6.0.0
@@ -164,9 +151,6 @@ version.junit.jupiter=5.14.2
 ##        # available=6.0.2
 
 version.junit.junit=4.13.2
-
-## unused
-version.io.gitlab.arturbosch.detekt..detekt-formatting=1.23.8
 
 # Dagger/Hilt 2.59 upgrade failed (2026-01-31). See plugin.com.google.dagger.hilt.android above.
 version.google.dagger=2.58


### PR DESCRIPTION
Upgrading Kotlin to 2.3 and Detekt to 2 since they need to be upgraded together. 

Ktlint has been disabled since it currently does not correctly format class and function arguments. 