### PR TITLE
[EDIFIKANA] Pass the email from the sign in page to the sign up page

### DIFF
--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/controller/authentication/SupabaseContextRetriever.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/controller/authentication/SupabaseContextRetriever.kt
@@ -6,6 +6,7 @@ import com.cramsan.framework.assertlib.assertNull
 import com.cramsan.framework.core.ktor.auth.ClientContext
 import com.cramsan.framework.core.ktor.auth.ContextRetriever
 import com.cramsan.framework.logging.logD
+import com.cramsan.framework.logging.logW
 import io.github.jan.supabase.auth.Auth
 import io.ktor.server.application.ApplicationCall
 
@@ -28,7 +29,12 @@ class SupabaseContextRetriever(
             return ClientContext.UnauthenticatedClientContext()
         }
 
-        val user = auth.retrieveUser(token)
+        val user = try {
+            auth.retrieveUser(token)
+        } catch (e: Exception) {
+            logW(TAG, "Error retrieving user from Supabase token: ${e.message}")
+            return ClientContext.UnauthenticatedClientContext()
+        }
         assertNull(auth.currentUserOrNull(), TAG, "Library cannot sign in user")
 
         return ClientContext.AuthenticatedClientContext(

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/auth/AuthActivityScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/auth/AuthActivityScreen.kt
@@ -35,7 +35,9 @@ fun NavGraphBuilder.authNavGraphNavigation(
             AuthDestination.SignUpDestination::class,
             typeMap = typeMap,
         ) {
-            SignUpScreen()
+            SignUpScreen(
+                destination = it.toRoute()
+            )
         }
         composable(
             AuthDestination.ValidationDestination::class,

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/auth/AuthDestination.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/auth/AuthDestination.kt
@@ -20,7 +20,9 @@ sealed class AuthDestination : Destination {
      * A class representing navigating to the sign up screen.
      */
     @Serializable
-    data object SignUpDestination : AuthDestination()
+    data class SignUpDestination(
+        val userEmail: String,
+    ) : AuthDestination()
 
     /**
      * A class representing navigating to the validation screen.

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/auth/signin/SignInViewModel.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/auth/signin/SignInViewModel.kt
@@ -145,7 +145,7 @@ class SignInViewModel(
                 )
             } else {
                 emitWindowEvent(
-                    EdifikanaWindowsEvent.NavigateToScreen(AuthDestination.SignUpDestination)
+                    EdifikanaWindowsEvent.NavigateToScreen(AuthDestination.SignUpDestination(email))
                 )
             }
         }
@@ -156,8 +156,9 @@ class SignInViewModel(
      */
     fun navigateToSignUpPage() {
         viewModelScope.launch {
+            val email = uiState.value.email.trim()
             emitWindowEvent(
-                EdifikanaWindowsEvent.NavigateToScreen(AuthDestination.SignUpDestination)
+                EdifikanaWindowsEvent.NavigateToScreen(AuthDestination.SignUpDestination(email))
             )
         }
     }

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/auth/signup/SignUpScreen.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/auth/signup/SignUpScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
+import com.cramsan.edifikana.client.lib.features.auth.AuthDestination
 import com.cramsan.edifikana.client.ui.components.EdifikanaTextField
 import com.cramsan.edifikana.client.ui.components.EdifikanaTopBar
 import com.cramsan.framework.core.compose.ui.ObserveViewModelEvents
@@ -46,12 +47,13 @@ import org.koin.compose.viewmodel.koinViewModel
  */
 @Composable
 fun SignUpScreen(
+    destination: AuthDestination.SignUpDestination,
     viewModel: SignUpViewModel = koinViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
 
     LifecycleEventEffect(Lifecycle.Event.ON_CREATE) {
-        viewModel.initializePage()
+        viewModel.initializePage(destination)
     }
 
     LifecycleEventEffect(Lifecycle.Event.ON_STOP) {

--- a/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/auth/signup/SignUpViewModel.kt
+++ b/edifikana/front-end/shared-app/src/commonMain/kotlin/com/cramsan/edifikana/client/lib/features/auth/signup/SignUpViewModel.kt
@@ -28,8 +28,16 @@ class SignUpViewModel(
     /**
      * Initialize the page.
      */
-    fun initializePage() {
+    fun initializePage(destination: AuthDestination.SignUpDestination) {
         logI(TAG, "SignUpViewModel initialized")
+        viewModelScope.launch {
+            updateUiState {
+                it.copy(
+                    email = destination.userEmail,
+                    errorMessages = emptyList()
+                )
+            }
+        }
     }
 
     /**

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/auth/signin/SignInViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/auth/signin/SignInViewModelTest.kt
@@ -235,7 +235,7 @@ class SignInViewModelTest : CoroutineTest() {
         val verificationJob = launch {
             windowEventBus.events.test {
                 assertEquals(
-                    EdifikanaWindowsEvent.NavigateToScreen(AuthDestination.SignUpDestination),
+                    EdifikanaWindowsEvent.NavigateToScreen(AuthDestination.SignUpDestination("")),
                     awaitItem()
                 )
             }
@@ -310,7 +310,7 @@ class SignInViewModelTest : CoroutineTest() {
         val verificationJob = launch {
             windowEventBus.events.test {
                 assertEquals(
-                    EdifikanaWindowsEvent.NavigateToScreen(AuthDestination.SignUpDestination),
+                    EdifikanaWindowsEvent.NavigateToScreen(AuthDestination.SignUpDestination(email)),
                     awaitItem()
                 )
             }

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/auth/signup/SignUpViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/auth/signup/SignUpViewModelTest.kt
@@ -69,11 +69,24 @@ class SignUpViewModelTest : CoroutineTest() {
      */
     @Test
     fun `test initializePage has expected UI state`() = runCoroutineTest {
+        // Arrange
+        val destination = AuthDestination.SignUpDestination(
+            userEmail = "user@test.com"
+        )
+
         // Act
-        viewModel.initializePage()
+        viewModel.initializePage(destination)
 
         // Assert
-        assertEquals(SignUpUIState.Initial, viewModel.uiState.value)
+        assertEquals("user@test.com", viewModel.uiState.value.email)
+        assertEquals("", viewModel.uiState.value.firstName)
+        assertEquals("", viewModel.uiState.value.lastName)
+        assertEquals("user@test.com", viewModel.uiState.value.email)
+        assertEquals("", viewModel.uiState.value.phoneNumber)
+        assertFalse(viewModel.uiState.value.policyChecked)
+        assertFalse(viewModel.uiState.value.registerEnabled)
+        assertEquals(emptyList(), viewModel.uiState.value.errorMessages)
+
     }
 
     /**

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/auth/signup/SignUpViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/auth/signup/SignUpViewModelTest.kt
@@ -81,7 +81,6 @@ class SignUpViewModelTest : CoroutineTest() {
         assertEquals("user@test.com", viewModel.uiState.value.email)
         assertEquals("", viewModel.uiState.value.firstName)
         assertEquals("", viewModel.uiState.value.lastName)
-        assertEquals("user@test.com", viewModel.uiState.value.email)
         assertEquals("", viewModel.uiState.value.phoneNumber)
         assertFalse(viewModel.uiState.value.policyChecked)
         assertFalse(viewModel.uiState.value.registerEnabled)


### PR DESCRIPTION
The email was not being passed from the Sign In page to the Sign Up page. This change add a parameter to the SignUpDestination so that we can pass the email.

This PR also has a fix for the cases of expired client tokens being sent from the client, which previously would throw a 401 failure. Even from endpoints that do did not require authentication. 

https://github.com/user-attachments/assets/bcee8d0f-559c-4669-a745-dc1cee8d2672

