### PR TITLE
[TEST] Remove old flow test pattern 

### DIFF
--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/account/account/AccountViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/account/account/AccountViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.cramsan.edifikana.client.lib.features.account.account
 
-import app.cash.turbine.test
+import app.cash.turbine.turbineScope
+import com.cramsan.framework.test.advanceUntilIdleAndAwaitComplete
 import com.cramsan.edifikana.client.lib.features.window.EdifikanaNavGraphDestination
 import com.cramsan.edifikana.client.lib.features.window.EdifikanaWindowsEvent
 import com.cramsan.edifikana.client.lib.managers.AuthManager
@@ -21,7 +22,6 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlinx.coroutines.launch
 import org.junit.jupiter.api.BeforeEach
 
 class AccountViewModelTest : CoroutineTest() {
@@ -54,24 +54,20 @@ class AccountViewModelTest : CoroutineTest() {
         // Arrange
         coEvery { authManager.signOut() } returns Result.success(Unit)
 
-        // Act
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.NavigateToNavGraph(
-                        EdifikanaNavGraphDestination.AuthNavGraphDestination,
-                        clearStack = true,
-                    ),
-                    awaitItem(),
-                )
-            }
+        // Act & Assert
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.signOut()
+            assertEquals(
+                EdifikanaWindowsEvent.NavigateToNavGraph(
+                    EdifikanaNavGraphDestination.AuthNavGraphDestination,
+                    clearStack = true,
+                ),
+                turbine.awaitItem(),
+            )
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        viewModel.signOut()
-
-        // Assert
         coVerify { authManager.signOut() }
-        verificationJob.join()
     }
 
     @Test
@@ -79,19 +75,13 @@ class AccountViewModelTest : CoroutineTest() {
         // Arrange
         assertEquals(false, viewModel.uiState.value.isEditable)
 
-        // Act
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.NavigateBack,
-                    awaitItem(),
-                )
-            }
+        // Act & Assert
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.navigateBack()
+            assertEquals(EdifikanaWindowsEvent.NavigateBack, turbine.awaitItem())
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-        viewModel.navigateBack()
-
-        // Assert
-        verificationJob.join()
     }
 
     @Test
@@ -248,19 +238,16 @@ class AccountViewModelTest : CoroutineTest() {
         viewModel.updatePhoneNumber("9876543210")
         assertEquals(true, viewModel.uiState.value.isEditable)
 
-        // Act
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.ShowSnackbar("Account information updated successfully."),
-                    awaitItem(),
-                )
-            }
+        // Act & Assert
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.editOrSave()
+            assertEquals(
+                EdifikanaWindowsEvent.ShowSnackbar("Account information updated successfully."),
+                turbine.awaitItem(),
+            )
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        viewModel.editOrSave()
-
-        // Assert
         coVerify {
             authManager.updateUser(
                 firstName = "Jane",
@@ -272,7 +259,6 @@ class AccountViewModelTest : CoroutineTest() {
         val uiState = viewModel.uiState.value
         assertEquals(false, uiState.isLoading)
         assertEquals(false, uiState.isEditable)
-        verificationJob.join()
     }
 
     @Test
@@ -291,22 +277,18 @@ class AccountViewModelTest : CoroutineTest() {
         viewModel.editOrSave()
         assertEquals(true, viewModel.uiState.value.isEditable)
 
-        // Act
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.ShowSnackbar("Failed to update account information. Please try again."),
-                    awaitItem(),
-                )
-            }
+        // Act & Assert
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.editOrSave()
+            assertEquals(
+                EdifikanaWindowsEvent.ShowSnackbar("Failed to update account information. Please try again."),
+                turbine.awaitItem(),
+            )
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        viewModel.editOrSave()
-
-        // Assert
         val uiState = viewModel.uiState.value
         assertEquals(false, uiState.isLoading)
         assertEquals(true, uiState.isEditable) // Should stay in edit mode on failure
-        verificationJob.join()
     }
 }

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/account/account/AccountViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/account/account/AccountViewModelTest.kt
@@ -54,10 +54,14 @@ class AccountViewModelTest : CoroutineTest() {
         // Arrange
         coEvery { authManager.signOut() } returns Result.success(Unit)
 
-        // Act & Assert
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.signOut()
+
+            // Assert
             assertEquals(
                 EdifikanaWindowsEvent.NavigateToNavGraph(
                     EdifikanaNavGraphDestination.AuthNavGraphDestination,
@@ -75,10 +79,14 @@ class AccountViewModelTest : CoroutineTest() {
         // Arrange
         assertEquals(false, viewModel.uiState.value.isEditable)
 
-        // Act & Assert
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.navigateBack()
+
+            // Assert
             assertEquals(EdifikanaWindowsEvent.NavigateBack, turbine.awaitItem())
             advanceUntilIdleAndAwaitComplete(turbine)
         }
@@ -238,10 +246,14 @@ class AccountViewModelTest : CoroutineTest() {
         viewModel.updatePhoneNumber("9876543210")
         assertEquals(true, viewModel.uiState.value.isEditable)
 
-        // Act & Assert
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.editOrSave()
+
+            // Assert
             assertEquals(
                 EdifikanaWindowsEvent.ShowSnackbar("Account information updated successfully."),
                 turbine.awaitItem(),
@@ -277,10 +289,14 @@ class AccountViewModelTest : CoroutineTest() {
         viewModel.editOrSave()
         assertEquals(true, viewModel.uiState.value.isEditable)
 
-        // Act & Assert
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.editOrSave()
+
+            // Assert
             assertEquals(
                 EdifikanaWindowsEvent.ShowSnackbar("Failed to update account information. Please try again."),
                 turbine.awaitItem(),

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/account/changepassword/ChangePasswordDialogViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/account/changepassword/ChangePasswordDialogViewModelTest.kt
@@ -107,11 +107,16 @@ class ChangePasswordDialogViewModelTest : CoroutineTest() {
         coEvery { authManager.changePassword(any(), any()) } returns Result.success(Unit)
 
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
             viewModel.onCurrentPasswordChange("oldPassword1!")
             viewModel.onNewPasswordChange("newPassword1!")
             viewModel.onConfirmPasswordChange("newPassword1!")
+
+            // Act
             viewModel.onSubmitSelected()
+
+            // Assert
             assertInstanceOf<EdifikanaWindowsEvent.ShowSnackbar>(turbine.awaitItem())
             assertEquals(EdifikanaWindowsEvent.NavigateBack, turbine.awaitItem())
             advanceUntilIdleAndAwaitComplete(turbine)

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/account/changepassword/ChangePasswordDialogViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/account/changepassword/ChangePasswordDialogViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.cramsan.edifikana.client.lib.features.account.changepassword
 
-import app.cash.turbine.test
+import app.cash.turbine.turbineScope
+import com.cramsan.framework.test.advanceUntilIdleAndAwaitComplete
 import com.cramsan.edifikana.client.lib.features.window.EdifikanaWindowsEvent
 import com.cramsan.edifikana.client.lib.managers.AuthManager
 import com.cramsan.edifikana.client.lib.models.UserModel
@@ -19,7 +20,6 @@ import com.cramsan.framework.test.CoroutineTest
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import kotlinx.coroutines.launch
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.assertInstanceOf
 import kotlin.test.Test
@@ -106,17 +106,16 @@ class ChangePasswordDialogViewModelTest : CoroutineTest() {
     fun `onSubmitSelected success emits NavigateBack`() = runCoroutineTest {
         coEvery { authManager.changePassword(any(), any()) } returns Result.success(Unit)
 
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                viewModel.onCurrentPasswordChange("oldPassword1!")
-                viewModel.onNewPasswordChange("newPassword1!")
-                viewModel.onConfirmPasswordChange("newPassword1!")
-                viewModel.onSubmitSelected()
-                assertInstanceOf<EdifikanaWindowsEvent.ShowSnackbar>(awaitItem())
-                assertEquals(EdifikanaWindowsEvent.NavigateBack, awaitItem())
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.onCurrentPasswordChange("oldPassword1!")
+            viewModel.onNewPasswordChange("newPassword1!")
+            viewModel.onConfirmPasswordChange("newPassword1!")
+            viewModel.onSubmitSelected()
+            assertInstanceOf<EdifikanaWindowsEvent.ShowSnackbar>(turbine.awaitItem())
+            assertEquals(EdifikanaWindowsEvent.NavigateBack, turbine.awaitItem())
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-        verificationJob.join()
         coVerify { authManager.changePassword(any(), any()) }
     }
 

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/account/notifications/NotificationsViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/account/notifications/NotificationsViewModelTest.kt
@@ -72,10 +72,14 @@ class NotificationsViewModelTest : CoroutineTest() {
      */
     @Test
     fun `test onBackSelected emits NavigateBack event`() = runCoroutineTest {
-        // Act & Assert
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.onBackSelected()
+
+            // Assert
             assertEquals(EdifikanaWindowsEvent.NavigateBack, turbine.awaitItem())
             advanceUntilIdleAndAwaitComplete(turbine)
         }
@@ -121,8 +125,13 @@ class NotificationsViewModelTest : CoroutineTest() {
         coEvery { notificationManager.getNotifications() } returns Result.failure(Exception("Network error"))
 
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.initialize()
+
+            // Assert
             assertEquals(
                 EdifikanaWindowsEvent.ShowSnackbar("Failed to load notifications: Network error"),
                 turbine.awaitItem()
@@ -142,8 +151,13 @@ class NotificationsViewModelTest : CoroutineTest() {
         coEvery { notificationManager.getNotifications() } returns Result.success(emptyList())
 
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.acceptInvite(inviteId)
+
+            // Assert
             assertEquals(
                 EdifikanaWindowsEvent.ShowSnackbar("Invitation accepted successfully"),
                 turbine.awaitItem()
@@ -162,8 +176,13 @@ class NotificationsViewModelTest : CoroutineTest() {
         coEvery { authManager.acceptInvite(inviteId) } returns Result.failure(Exception("Accept failed"))
 
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.acceptInvite(inviteId)
+
+            // Assert
             assertEquals(
                 EdifikanaWindowsEvent.ShowSnackbar("Failed to accept invitation: Accept failed"),
                 turbine.awaitItem()
@@ -182,8 +201,13 @@ class NotificationsViewModelTest : CoroutineTest() {
         coEvery { notificationManager.getNotifications() } returns Result.success(emptyList())
 
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.declineInvite(inviteId)
+
+            // Assert
             assertEquals(
                 EdifikanaWindowsEvent.ShowSnackbar("Invitation declined"),
                 turbine.awaitItem()
@@ -201,8 +225,13 @@ class NotificationsViewModelTest : CoroutineTest() {
         coEvery { authManager.declineInvite(inviteId) } returns Result.failure(Exception("Decline failed"))
 
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.declineInvite(inviteId)
+
+            // Assert
             assertEquals(
                 EdifikanaWindowsEvent.ShowSnackbar("Failed to decline invitation: Decline failed"),
                 turbine.awaitItem()

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/account/notifications/NotificationsViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/account/notifications/NotificationsViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.cramsan.edifikana.client.lib.features.account.notifications
 
-import app.cash.turbine.test
+import app.cash.turbine.turbineScope
+import com.cramsan.framework.test.advanceUntilIdleAndAwaitComplete
 import com.cramsan.edifikana.client.lib.features.window.EdifikanaWindowsEvent
 import com.cramsan.edifikana.client.lib.managers.AuthManager
 import com.cramsan.edifikana.client.lib.managers.NotificationManager
@@ -21,7 +22,6 @@ import com.cramsan.framework.test.CoroutineTest
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import kotlinx.coroutines.launch
 import org.junit.jupiter.api.BeforeEach
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -72,19 +72,13 @@ class NotificationsViewModelTest : CoroutineTest() {
      */
     @Test
     fun `test onBackSelected emits NavigateBack event`() = runCoroutineTest {
-        // Act
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.NavigateBack,
-                    awaitItem()
-                )
-            }
+        // Act & Assert
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.onBackSelected()
+            assertEquals(EdifikanaWindowsEvent.NavigateBack, turbine.awaitItem())
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-        viewModel.onBackSelected()
-
-        // Assert
-        verificationJob.join()
     }
 
     @Test
@@ -126,17 +120,15 @@ class NotificationsViewModelTest : CoroutineTest() {
     fun `test initialize with failure shows error snackbar`() = runCoroutineTest {
         coEvery { notificationManager.getNotifications() } returns Result.failure(Exception("Network error"))
 
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.ShowSnackbar("Failed to load notifications: Network error"),
-                    awaitItem()
-                )
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.initialize()
+            assertEquals(
+                EdifikanaWindowsEvent.ShowSnackbar("Failed to load notifications: Network error"),
+                turbine.awaitItem()
+            )
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        viewModel.initialize()
-        verificationJob.join()
 
         assertEquals(false, viewModel.uiState.value.isLoading)
         assertEquals(emptyList(), viewModel.uiState.value.notifications)
@@ -149,17 +141,15 @@ class NotificationsViewModelTest : CoroutineTest() {
         coEvery { authManager.acceptInvite(inviteId) } returns Result.success(Unit)
         coEvery { notificationManager.getNotifications() } returns Result.success(emptyList())
 
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.ShowSnackbar("Invitation accepted successfully"),
-                    awaitItem()
-                )
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.acceptInvite(inviteId)
+            assertEquals(
+                EdifikanaWindowsEvent.ShowSnackbar("Invitation accepted successfully"),
+                turbine.awaitItem()
+            )
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        viewModel.acceptInvite(inviteId)
-        verificationJob.join()
 
         coVerify { authManager.acceptInvite(inviteId) }
         coVerify(atLeast = 1) { notificationManager.getNotifications() }
@@ -171,17 +161,15 @@ class NotificationsViewModelTest : CoroutineTest() {
 
         coEvery { authManager.acceptInvite(inviteId) } returns Result.failure(Exception("Accept failed"))
 
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.ShowSnackbar("Failed to accept invitation: Accept failed"),
-                    awaitItem()
-                )
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.acceptInvite(inviteId)
+            assertEquals(
+                EdifikanaWindowsEvent.ShowSnackbar("Failed to accept invitation: Accept failed"),
+                turbine.awaitItem()
+            )
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        viewModel.acceptInvite(inviteId)
-        verificationJob.join()
 
         assertEquals(false, viewModel.uiState.value.isLoading)
     }
@@ -193,17 +181,15 @@ class NotificationsViewModelTest : CoroutineTest() {
         coEvery { authManager.declineInvite(inviteId) } returns Result.success(Unit)
         coEvery { notificationManager.getNotifications() } returns Result.success(emptyList())
 
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.ShowSnackbar("Invitation declined"),
-                    awaitItem()
-                )
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.declineInvite(inviteId)
+            assertEquals(
+                EdifikanaWindowsEvent.ShowSnackbar("Invitation declined"),
+                turbine.awaitItem()
+            )
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        viewModel.declineInvite(inviteId)
-        verificationJob.join()
 
         coVerify { authManager.declineInvite(inviteId) }
     }
@@ -214,17 +200,15 @@ class NotificationsViewModelTest : CoroutineTest() {
 
         coEvery { authManager.declineInvite(inviteId) } returns Result.failure(Exception("Decline failed"))
 
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.ShowSnackbar("Failed to decline invitation: Decline failed"),
-                    awaitItem()
-                )
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.declineInvite(inviteId)
+            assertEquals(
+                EdifikanaWindowsEvent.ShowSnackbar("Failed to decline invitation: Decline failed"),
+                turbine.awaitItem()
+            )
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        viewModel.declineInvite(inviteId)
-        verificationJob.join()
 
         assertEquals(false, viewModel.uiState.value.isLoading)
     }

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/auth/onboarding/selectorg/SelectOrgViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/auth/onboarding/selectorg/SelectOrgViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.cramsan.edifikana.client.lib.features.auth.onboarding.selectorg
 
-import app.cash.turbine.test
+import app.cash.turbine.turbineScope
+import com.cramsan.framework.test.advanceUntilIdleAndAwaitComplete
 import com.cramsan.edifikana.client.lib.features.auth.AuthDestination
 import com.cramsan.edifikana.client.lib.features.window.EdifikanaNavGraphDestination
 import com.cramsan.edifikana.client.lib.features.window.EdifikanaWindowsEvent
@@ -22,7 +23,6 @@ import io.mockk.mockk
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlinx.coroutines.launch
 
 /**
  * Unit tests for [SelectOrgViewModel].
@@ -74,19 +74,16 @@ class SelectOrgViewModelTest : CoroutineTest() {
 
     @Test
     fun `test createOrganization emits NavigateToScreen event`() = runCoroutineTest {
-        // Act
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.NavigateToScreen(AuthDestination.CreateNewOrgDestination),
-                    awaitItem()
-                )
-            }
+        // Act & Assert
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.createOrganization()
+            assertEquals(
+                EdifikanaWindowsEvent.NavigateToScreen(AuthDestination.CreateNewOrgDestination),
+                turbine.awaitItem()
+            )
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-        viewModel.createOrganization()
-
-        // Assert
-        verificationJob.join()
     }
 
     @Test
@@ -97,22 +94,21 @@ class SelectOrgViewModelTest : CoroutineTest() {
 
     @Test
     fun `test confirmSignOut calls signOut and emits NavigateToNavGraph event`() = runCoroutineTest {
-        // Act
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.NavigateToNavGraph(
-                        EdifikanaNavGraphDestination.AuthNavGraphDestination,
-                        clearStack = true,
-                    ),
-                    awaitItem()
-                )
-            }
+        // Act & Assert
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.confirmSignOut()
+            assertEquals(
+                EdifikanaWindowsEvent.NavigateToNavGraph(
+                    EdifikanaNavGraphDestination.AuthNavGraphDestination,
+                    clearStack = true,
+                ),
+                turbine.awaitItem()
+            )
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-        viewModel.confirmSignOut()
 
         // Assert
         coVerify { authManager.signOut() }
-        verificationJob.join()
     }
 }

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/auth/onboarding/selectorg/SelectOrgViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/auth/onboarding/selectorg/SelectOrgViewModelTest.kt
@@ -74,10 +74,14 @@ class SelectOrgViewModelTest : CoroutineTest() {
 
     @Test
     fun `test createOrganization emits NavigateToScreen event`() = runCoroutineTest {
-        // Act & Assert
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.createOrganization()
+
+            // Assert
             assertEquals(
                 EdifikanaWindowsEvent.NavigateToScreen(AuthDestination.CreateNewOrgDestination),
                 turbine.awaitItem()
@@ -94,10 +98,14 @@ class SelectOrgViewModelTest : CoroutineTest() {
 
     @Test
     fun `test confirmSignOut calls signOut and emits NavigateToNavGraph event`() = runCoroutineTest {
-        // Act & Assert
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.confirmSignOut()
+
+            // Assert
             assertEquals(
                 EdifikanaWindowsEvent.NavigateToNavGraph(
                     EdifikanaNavGraphDestination.AuthNavGraphDestination,

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/auth/signin/SignInViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/auth/signin/SignInViewModelTest.kt
@@ -1,6 +1,5 @@
 package com.cramsan.edifikana.client.lib.features.auth.signin
 
-import app.cash.turbine.test
 import app.cash.turbine.turbineScope
 import com.cramsan.architecture.client.manager.PreferencesManager
 import com.cramsan.edifikana.client.lib.features.auth.AuthDestination
@@ -29,7 +28,6 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlinx.coroutines.launch
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
@@ -173,20 +171,16 @@ class SignInViewModelTest : CoroutineTest() {
         viewModel.changeUsernameValue(username)
         viewModel.changePasswordValue(password)
 
-        // Act
-        val verificationJob = launch {
-            viewModel.events.test {
-                advanceUntilIdleAndAwaitComplete(this)
-            }
+        // Act & Assert & Verify
+        turbineScope {
+            val turbine = viewModel.events.testIn(backgroundScope)
+            viewModel.changeUsernameValue(username)
+            viewModel.changePasswordValue(password)
+            viewModel.signInWithPassword()
+            coVerify { authManager.signInWithPassword(username, password) }
+            assertEquals(listOf(errorMessage).toString(), viewModel.uiState.value.errorMessages.toString())
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-        viewModel.changeUsernameValue(username)
-        viewModel.changePasswordValue(password)
-        viewModel.signInWithPassword()
-
-        // Assert & Verify
-        coVerify { authManager.signInWithPassword(username, password) }
-        assertEquals(listOf(errorMessage).toString(), viewModel.uiState.value.errorMessages.toString())
-        verificationJob.join()
     }
 
     /**
@@ -207,20 +201,16 @@ class SignInViewModelTest : CoroutineTest() {
         } returns Result.failure(mockk<Exception>())
         coEvery { stringProvider.getString(Res.string.error_message_unexpected_error) } returns errorMessage
 
-        // Act
-        val verificationJob = launch {
-            viewModel.events.test {
-                advanceUntilIdleAndAwaitComplete(this)
-            }
+        // Act & Assert & Verify
+        turbineScope {
+            val turbine = viewModel.events.testIn(backgroundScope)
+            viewModel.changeUsernameValue(username)
+            viewModel.changePasswordValue(password)
+            viewModel.signInWithPassword()
+            coVerify { authManager.signInWithPassword(username, password) }
+            assertEquals(listOf(errorMessage).toString(), viewModel.uiState.value.errorMessages.toString())
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-        viewModel.changeUsernameValue(username)
-        viewModel.changePasswordValue(password)
-        viewModel.signInWithPassword()
-
-        // Assert & Verify
-        coVerify { authManager.signInWithPassword(username, password) }
-        assertEquals(listOf(errorMessage).toString(), viewModel.uiState.value.errorMessages.toString())
-        verificationJob.join()
     }
 
     /**
@@ -231,19 +221,16 @@ class SignInViewModelTest : CoroutineTest() {
         // Arrange
         coEvery { authManager.signInWithPassword(any(), any()) } returns Result.success(mockk())
 
-        // Act
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.NavigateToScreen(AuthDestination.SignUpDestination("")),
-                    awaitItem()
-                )
-            }
+        // Act & Assert & Verify
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.navigateToSignUpPage()
+            assertEquals(
+                EdifikanaWindowsEvent.NavigateToScreen(AuthDestination.SignUpDestination("")),
+                turbine.awaitItem()
+            )
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-        viewModel.navigateToSignUpPage()
-
-        // Assert & Verify
-        verificationJob.join()
     }
 
     /**
@@ -254,19 +241,16 @@ class SignInViewModelTest : CoroutineTest() {
         // Arrange
         coEvery { authManager.signInWithPassword(any(), any()) } returns Result.success(mockk())
 
-        // Act
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.NavigateToNavGraph(EdifikanaNavGraphDestination.DebugNavGraphDestination),
-                    awaitItem()
-                )
-            }
+        // Act & Assert & Verify
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.navigateToDebugPage()
+            assertEquals(
+                EdifikanaWindowsEvent.NavigateToNavGraph(EdifikanaNavGraphDestination.DebugNavGraphDestination),
+                turbine.awaitItem()
+            )
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-        viewModel.navigateToDebugPage()
-
-        // Assert & Verify
-        verificationJob.join()
     }
 
     /**
@@ -279,24 +263,21 @@ class SignInViewModelTest : CoroutineTest() {
         viewModel.changeUsernameValue(email)
         coEvery { authManager.checkUserExists(email.trim()) } returns Result.success(true)
 
-        // Act
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.NavigateToScreen(
-                        AuthDestination.ValidationDestination(
-                            email.trim(),
-                            accountCreationFlow = false,
-                        )
-                    ),
-                    awaitItem()
-                )
-            }
+        // Act & Assert
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.signInWithOtp()
+            assertEquals(
+                EdifikanaWindowsEvent.NavigateToScreen(
+                    AuthDestination.ValidationDestination(
+                        email.trim(),
+                        accountCreationFlow = false,
+                    )
+                ),
+                turbine.awaitItem()
+            )
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-        viewModel.signInWithOtp()
-
-        // Assert
-        verificationJob.join()
     }
 
     @Test
@@ -306,19 +287,16 @@ class SignInViewModelTest : CoroutineTest() {
         viewModel.changeUsernameValue(email)
         coEvery { authManager.checkUserExists(email.trim()) } returns Result.success(false)
 
-        // Act
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.NavigateToScreen(AuthDestination.SignUpDestination(email)),
-                    awaitItem()
-                )
-            }
+        // Act & Assert & Verify
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.signInWithOtp()
+            assertEquals(
+                EdifikanaWindowsEvent.NavigateToScreen(AuthDestination.SignUpDestination(email)),
+                turbine.awaitItem()
+            )
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-        viewModel.signInWithOtp()
-
-        // Assert & Verify
         coVerify { authManager.checkUserExists(email.trim()) }
-        verificationJob.join()
     }
 }

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/auth/signin/SignInViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/auth/signin/SignInViewModelTest.kt
@@ -140,7 +140,7 @@ class SignInViewModelTest : CoroutineTest() {
         viewModel.changePasswordValue(password)
         viewModel.signInWithPassword()
 
-        // Verify
+        // Assert
         coVerify { authManager.signInWithPassword(username, password) }
         assertEquals(
             EdifikanaWindowsEvent.NavigateToNavGraph(
@@ -171,12 +171,16 @@ class SignInViewModelTest : CoroutineTest() {
         viewModel.changeUsernameValue(username)
         viewModel.changePasswordValue(password)
 
-        // Act & Assert & Verify
         turbineScope {
+            // Arrange
             val turbine = viewModel.events.testIn(backgroundScope)
+
+            // Act
             viewModel.changeUsernameValue(username)
             viewModel.changePasswordValue(password)
             viewModel.signInWithPassword()
+
+            // Assert
             coVerify { authManager.signInWithPassword(username, password) }
             assertEquals(listOf(errorMessage).toString(), viewModel.uiState.value.errorMessages.toString())
             advanceUntilIdleAndAwaitComplete(turbine)
@@ -201,12 +205,16 @@ class SignInViewModelTest : CoroutineTest() {
         } returns Result.failure(mockk<Exception>())
         coEvery { stringProvider.getString(Res.string.error_message_unexpected_error) } returns errorMessage
 
-        // Act & Assert & Verify
         turbineScope {
+            // Arrange
             val turbine = viewModel.events.testIn(backgroundScope)
+
+            // Act
             viewModel.changeUsernameValue(username)
             viewModel.changePasswordValue(password)
             viewModel.signInWithPassword()
+
+            // Assert
             coVerify { authManager.signInWithPassword(username, password) }
             assertEquals(listOf(errorMessage).toString(), viewModel.uiState.value.errorMessages.toString())
             advanceUntilIdleAndAwaitComplete(turbine)
@@ -221,10 +229,14 @@ class SignInViewModelTest : CoroutineTest() {
         // Arrange
         coEvery { authManager.signInWithPassword(any(), any()) } returns Result.success(mockk())
 
-        // Act & Assert & Verify
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.navigateToSignUpPage()
+
+            // Assert
             assertEquals(
                 EdifikanaWindowsEvent.NavigateToScreen(AuthDestination.SignUpDestination("")),
                 turbine.awaitItem()
@@ -241,10 +253,14 @@ class SignInViewModelTest : CoroutineTest() {
         // Arrange
         coEvery { authManager.signInWithPassword(any(), any()) } returns Result.success(mockk())
 
-        // Act & Assert & Verify
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.navigateToDebugPage()
+
+            // Assert
             assertEquals(
                 EdifikanaWindowsEvent.NavigateToNavGraph(EdifikanaNavGraphDestination.DebugNavGraphDestination),
                 turbine.awaitItem()
@@ -263,10 +279,14 @@ class SignInViewModelTest : CoroutineTest() {
         viewModel.changeUsernameValue(email)
         coEvery { authManager.checkUserExists(email.trim()) } returns Result.success(true)
 
-        // Act & Assert
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.signInWithOtp()
+
+            // Assert
             assertEquals(
                 EdifikanaWindowsEvent.NavigateToScreen(
                     AuthDestination.ValidationDestination(
@@ -287,10 +307,14 @@ class SignInViewModelTest : CoroutineTest() {
         viewModel.changeUsernameValue(email)
         coEvery { authManager.checkUserExists(email.trim()) } returns Result.success(false)
 
-        // Act & Assert & Verify
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.signInWithOtp()
+
+            // Assert
             assertEquals(
                 EdifikanaWindowsEvent.NavigateToScreen(AuthDestination.SignUpDestination(email)),
                 turbine.awaitItem()

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/auth/signup/SignUpViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/auth/signup/SignUpViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.cramsan.edifikana.client.lib.features.auth.signup
 
-import app.cash.turbine.test
+import app.cash.turbine.turbineScope
+import com.cramsan.framework.test.advanceUntilIdleAndAwaitComplete
 import com.cramsan.edifikana.client.lib.features.auth.AuthDestination
 import com.cramsan.edifikana.client.lib.features.window.EdifikanaWindowsEvent
 import com.cramsan.edifikana.client.lib.managers.AuthManager
@@ -18,7 +19,6 @@ import com.cramsan.framework.test.CoroutineTest
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import kotlinx.coroutines.launch
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvFileSource
 import kotlin.test.BeforeTest
@@ -188,18 +188,13 @@ class SignUpViewModelTest : CoroutineTest() {
         // Arrange
         coEvery { authManager.signUp(any(), any(), any(), any()) } returns Result.success(mockk())
 
-        // Act
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.NavigateBack, awaitItem()
-                )
-            }
+        // Act & Verify
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.navigateBack()
+            assertEquals(EdifikanaWindowsEvent.NavigateBack, turbine.awaitItem())
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-        viewModel.navigateBack()
-
-        // Verify
-        verificationJob.join()
     }
 
     /**
@@ -225,27 +220,23 @@ class SignUpViewModelTest : CoroutineTest() {
         viewModel.onPhoneNumberValueChange(phoneNumber)
         viewModel.onPolicyChecked(true)
 
-        // Act
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.NavigateToScreen(
-                        destination= AuthDestination.ValidationDestination(
-                            userEmail="totalReal@email.com",
-                            accountCreationFlow=true
-                        ),
-                        clearTop=true,
-                        clearStack=false,
-                    ), awaitItem()
-                )
-            }
+        // Act & Verify
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.signUp()
+            coVerify { authManager.signUp(email, phoneNumber, firstName, lastName) }
+            assertEquals(
+                EdifikanaWindowsEvent.NavigateToScreen(
+                    destination= AuthDestination.ValidationDestination(
+                        userEmail="totalReal@email.com",
+                        accountCreationFlow=true
+                    ),
+                    clearTop=true,
+                    clearStack=false,
+                ), turbine.awaitItem()
+            )
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-        viewModel.signUp()
-
-
-        // Verify
-        coVerify { authManager.signUp(email, phoneNumber, firstName, lastName) }
-        verificationJob.join()
         assertTrue(viewModel.uiState.value.isLoading)
     }
 

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/auth/signup/SignUpViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/auth/signup/SignUpViewModelTest.kt
@@ -188,10 +188,14 @@ class SignUpViewModelTest : CoroutineTest() {
         // Arrange
         coEvery { authManager.signUp(any(), any(), any(), any()) } returns Result.success(mockk())
 
-        // Act & Verify
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.navigateBack()
+
+            // Assert
             assertEquals(EdifikanaWindowsEvent.NavigateBack, turbine.awaitItem())
             advanceUntilIdleAndAwaitComplete(turbine)
         }
@@ -220,10 +224,14 @@ class SignUpViewModelTest : CoroutineTest() {
         viewModel.onPhoneNumberValueChange(phoneNumber)
         viewModel.onPolicyChecked(true)
 
-        // Act & Verify
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.signUp()
+
+            // Assert
             coVerify { authManager.signUp(email, phoneNumber, firstName, lastName) }
             assertEquals(
                 EdifikanaWindowsEvent.NavigateToScreen(

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/auth/validation/OtpValidationViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/auth/validation/OtpValidationViewModelTest.kt
@@ -130,10 +130,14 @@ class OtpValidationViewModelTest : CoroutineTest() {
      */
     @Test
     fun `navigateBack should call emitEvent`() = runCoroutineTest {
-        // Act & Assert
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.navigateBack()
+
+            // Assert
             assertEquals(EdifikanaWindowsEvent.NavigateBack, turbine.awaitItem())
             advanceUntilIdleAndAwaitComplete(turbine)
         }

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/auth/validation/OtpValidationViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/auth/validation/OtpValidationViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.cramsan.edifikana.client.lib.features.auth.validation
 
-import app.cash.turbine.test
+import app.cash.turbine.turbineScope
+import com.cramsan.framework.test.advanceUntilIdleAndAwaitComplete
 import com.cramsan.edifikana.client.lib.features.window.EdifikanaWindowsEvent
 import com.cramsan.edifikana.client.lib.managers.AuthManager
 import com.cramsan.framework.core.UnifiedDispatcherProvider
@@ -16,7 +17,6 @@ import com.cramsan.framework.test.CoroutineTest
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import kotlinx.coroutines.launch
 import org.junit.jupiter.api.Assertions
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -130,18 +130,12 @@ class OtpValidationViewModelTest : CoroutineTest() {
      */
     @Test
     fun `navigateBack should call emitEvent`() = runCoroutineTest {
-        // Act
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.NavigateBack, awaitItem()
-                )
-            }
+        // Act & Assert
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.navigateBack()
+            assertEquals(EdifikanaWindowsEvent.NavigateBack, turbine.awaitItem())
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-        viewModel.navigateBack()
-        this.testScheduler.advanceUntilIdle()
-
-        // Assert
-        verificationJob.join()
     }
 }

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/addproperty/AddPropertyViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/addproperty/AddPropertyViewModelTest.kt
@@ -75,10 +75,14 @@ class AddPropertyViewModelTest : CoroutineTest() {
      */
     @Test
     fun `test navigateBack emits NavigateBack event`() = runCoroutineTest {
-        // Act & Assert
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.navigateBack()
+
+            // Assert
             assertEquals(EdifikanaWindowsEvent.NavigateBack, turbine.awaitItem())
             advanceUntilIdleAndAwaitComplete(turbine)
         }
@@ -110,11 +114,15 @@ class AddPropertyViewModelTest : CoroutineTest() {
             newProperty
         )
 
-        // Act & Assert
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
             viewModel.initialize(organizationId)
+
+            // Act
             viewModel.addProperty(propertyName, address, selectedIcon)
+
+            // Assert
             assertEquals(
                 EdifikanaWindowsEvent.ShowSnackbar("Property $propertyName added successfully"),
                 turbine.awaitItem()
@@ -147,11 +155,15 @@ class AddPropertyViewModelTest : CoroutineTest() {
             propertyManager.addProperty(propertyName, address, organizationId, imageUrl, null)
         } returns Result.failure(Exception("Error"))
 
-        // Act & Assert
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
             viewModel.initialize(organizationId)
+
+            // Act
             viewModel.addProperty(propertyName, address, selectedIcon)
+
+            // Assert
             val snackbarEvent = turbine.awaitItem() as EdifikanaWindowsEvent.ShowSnackbar
             assertTrue(snackbarEvent.message.contains("Failed to add property"))
             advanceUntilIdleAndAwaitComplete(turbine)
@@ -291,8 +303,8 @@ class AddPropertyViewModelTest : CoroutineTest() {
             propertyManager.addProperty(propertyName, address, organizationId, null, imageUri)
         } returns Result.success(newProperty.copy(imageUrl = "storage:$expectedStorageRef"))
 
-        // Act & Assert
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
             viewModel.initialize(organizationId)
             val selectedIcon = ImageOptionUIModel(
@@ -300,7 +312,11 @@ class AddPropertyViewModelTest : CoroutineTest() {
                 displayName = "Custom Image",
                 imageSource = ImageSource.LocalFile(imageUri, "test.jpg")
             )
+
+            // Act
             viewModel.addProperty(propertyName, address, selectedIcon)
+
+            // Assert
             val snackbarEvent = turbine.awaitItem() as EdifikanaWindowsEvent.ShowSnackbar
             assertTrue(snackbarEvent.message.contains("added with custom image"))
             assertEquals(EdifikanaWindowsEvent.NavigateBack, turbine.awaitItem())
@@ -331,8 +347,8 @@ class AddPropertyViewModelTest : CoroutineTest() {
             propertyManager.addProperty(propertyName, address, organizationId, null, imageUri)
         } returns Result.failure(ClientRequestExceptions.InvalidRequestException("Upload failed"))
 
-        // Act & Assert
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
             viewModel.initialize(organizationId)
             val selectedIcon = ImageOptionUIModel(
@@ -340,7 +356,11 @@ class AddPropertyViewModelTest : CoroutineTest() {
                 displayName = "Custom Image",
                 imageSource = ImageSource.LocalFile(imageUri, "test.jpg")
             )
+
+            // Act
             viewModel.addProperty(propertyName, address, selectedIcon)
+
+            // Assert
             val snackbarEvent = turbine.awaitItem() as EdifikanaWindowsEvent.ShowSnackbar
             assertTrue(snackbarEvent.message.contains("Failed to add property"))
             advanceUntilIdleAndAwaitComplete(turbine)
@@ -368,8 +388,8 @@ class AddPropertyViewModelTest : CoroutineTest() {
             propertyManager.addProperty(propertyName, address, organizationId, null, imageUri)
         } returns Result.failure(Exception("Property creation with image failed"))
 
-        // Act & Assert
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
             viewModel.initialize(organizationId)
             val selectedIcon = ImageOptionUIModel(
@@ -377,7 +397,11 @@ class AddPropertyViewModelTest : CoroutineTest() {
                 displayName = "Custom Image",
                 imageSource = ImageSource.LocalFile(imageUri, "test.jpg")
             )
+
+            // Act
             viewModel.addProperty(propertyName, address, selectedIcon)
+
+            // Assert
             val snackbarEvent = turbine.awaitItem() as EdifikanaWindowsEvent.ShowSnackbar
             assertTrue(snackbarEvent.message.contains("Failed to add property"))
             advanceUntilIdleAndAwaitComplete(turbine)

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/addproperty/AddPropertyViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/addproperty/AddPropertyViewModelTest.kt
@@ -1,7 +1,7 @@
 package com.cramsan.edifikana.client.lib.features.home.addproperty
 
-import app.cash.turbine.test
 import app.cash.turbine.turbineScope
+import com.cramsan.framework.test.advanceUntilIdleAndAwaitComplete
 import com.cramsan.edifikana.client.lib.features.window.EdifikanaWindowsEvent
 import com.cramsan.edifikana.client.lib.managers.PropertyManager
 import com.cramsan.edifikana.client.lib.managers.StorageManager
@@ -27,7 +27,6 @@ import com.cramsan.framework.utils.exceptions.ClientRequestExceptions
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import kotlinx.coroutines.launch
 import org.junit.jupiter.api.BeforeEach
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -76,20 +75,13 @@ class AddPropertyViewModelTest : CoroutineTest() {
      */
     @Test
     fun `test navigateBack emits NavigateBack event`() = runCoroutineTest {
-        // Arrange
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                // Assert
-                assertEquals(
-                    EdifikanaWindowsEvent.NavigateBack,
-                    awaitItem()
-                )
-            }
+        // Act & Assert
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.navigateBack()
+            assertEquals(EdifikanaWindowsEvent.NavigateBack, turbine.awaitItem())
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        // Act
-        viewModel.navigateBack()
-        verificationJob.join()
     }
 
     /**
@@ -118,23 +110,18 @@ class AddPropertyViewModelTest : CoroutineTest() {
             newProperty
         )
 
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                // Assert
-                assertEquals(
-                    EdifikanaWindowsEvent.ShowSnackbar(
-                        "Property $propertyName added successfully"
-                    ),
-                    awaitItem()
-                )
-                assertEquals(EdifikanaWindowsEvent.NavigateBack, awaitItem())
-            }
+        // Act & Assert
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.initialize(organizationId)
+            viewModel.addProperty(propertyName, address, selectedIcon)
+            assertEquals(
+                EdifikanaWindowsEvent.ShowSnackbar("Property $propertyName added successfully"),
+                turbine.awaitItem()
+            )
+            assertEquals(EdifikanaWindowsEvent.NavigateBack, turbine.awaitItem())
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        // Act
-        viewModel.initialize(organizationId)
-        viewModel.addProperty(propertyName, address, selectedIcon)
-        verificationJob.join()
 
         // Assert
         coVerify { propertyManager.addProperty(propertyName, address, organizationId, imageUrl) }
@@ -160,17 +147,15 @@ class AddPropertyViewModelTest : CoroutineTest() {
             propertyManager.addProperty(propertyName, address, organizationId, imageUrl, null)
         } returns Result.failure(Exception("Error"))
 
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                val snackbarEvent = awaitItem() as EdifikanaWindowsEvent.ShowSnackbar
-                assertTrue(snackbarEvent.message.contains("Failed to add property"))
-            }
+        // Act & Assert
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.initialize(organizationId)
+            viewModel.addProperty(propertyName, address, selectedIcon)
+            val snackbarEvent = turbine.awaitItem() as EdifikanaWindowsEvent.ShowSnackbar
+            assertTrue(snackbarEvent.message.contains("Failed to add property"))
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        // Act
-        viewModel.initialize(organizationId)
-        viewModel.addProperty(propertyName, address, selectedIcon)
-        verificationJob.join()
 
         // Assert
         assertEquals(false, viewModel.uiState.value.isLoading)
@@ -306,23 +291,21 @@ class AddPropertyViewModelTest : CoroutineTest() {
             propertyManager.addProperty(propertyName, address, organizationId, null, imageUri)
         } returns Result.success(newProperty.copy(imageUrl = "storage:$expectedStorageRef"))
 
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                val snackbarEvent = awaitItem() as EdifikanaWindowsEvent.ShowSnackbar
-                assertTrue(snackbarEvent.message.contains("added with custom image"))
-                assertEquals(EdifikanaWindowsEvent.NavigateBack, awaitItem())
-            }
+        // Act & Assert
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.initialize(organizationId)
+            val selectedIcon = ImageOptionUIModel(
+                id = "custom_local",
+                displayName = "Custom Image",
+                imageSource = ImageSource.LocalFile(imageUri, "test.jpg")
+            )
+            viewModel.addProperty(propertyName, address, selectedIcon)
+            val snackbarEvent = turbine.awaitItem() as EdifikanaWindowsEvent.ShowSnackbar
+            assertTrue(snackbarEvent.message.contains("added with custom image"))
+            assertEquals(EdifikanaWindowsEvent.NavigateBack, turbine.awaitItem())
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        // Act
-        viewModel.initialize(organizationId)
-        val selectedIcon = ImageOptionUIModel(
-            id = "custom_local",
-            displayName = "Custom Image",
-            imageSource = ImageSource.LocalFile(imageUri, "test.jpg")
-        )
-        viewModel.addProperty(propertyName, address, selectedIcon)
-        verificationJob.join()
 
         // Assert
         coVerify(exactly = 1) {
@@ -348,22 +331,20 @@ class AddPropertyViewModelTest : CoroutineTest() {
             propertyManager.addProperty(propertyName, address, organizationId, null, imageUri)
         } returns Result.failure(ClientRequestExceptions.InvalidRequestException("Upload failed"))
 
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                val snackbarEvent = awaitItem() as EdifikanaWindowsEvent.ShowSnackbar
-                assertTrue(snackbarEvent.message.contains("Failed to add property"))
-            }
+        // Act & Assert
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.initialize(organizationId)
+            val selectedIcon = ImageOptionUIModel(
+                id = "custom_local",
+                displayName = "Custom Image",
+                imageSource = ImageSource.LocalFile(imageUri, "test.jpg")
+            )
+            viewModel.addProperty(propertyName, address, selectedIcon)
+            val snackbarEvent = turbine.awaitItem() as EdifikanaWindowsEvent.ShowSnackbar
+            assertTrue(snackbarEvent.message.contains("Failed to add property"))
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        // Act
-        viewModel.initialize(organizationId)
-        val selectedIcon = ImageOptionUIModel(
-            id = "custom_local",
-            displayName = "Custom Image",
-            imageSource = ImageSource.LocalFile(imageUri, "test.jpg")
-        )
-        viewModel.addProperty(propertyName, address, selectedIcon)
-        verificationJob.join()
 
         // Assert
         coVerify(exactly = 1) {
@@ -387,22 +368,20 @@ class AddPropertyViewModelTest : CoroutineTest() {
             propertyManager.addProperty(propertyName, address, organizationId, null, imageUri)
         } returns Result.failure(Exception("Property creation with image failed"))
 
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                val snackbarEvent = awaitItem() as EdifikanaWindowsEvent.ShowSnackbar
-                assertTrue(snackbarEvent.message.contains("Failed to add property"))
-            }
+        // Act & Assert
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.initialize(organizationId)
+            val selectedIcon = ImageOptionUIModel(
+                id = "custom_local",
+                displayName = "Custom Image",
+                imageSource = ImageSource.LocalFile(imageUri, "test.jpg")
+            )
+            viewModel.addProperty(propertyName, address, selectedIcon)
+            val snackbarEvent = turbine.awaitItem() as EdifikanaWindowsEvent.ShowSnackbar
+            assertTrue(snackbarEvent.message.contains("Failed to add property"))
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        // Act
-        viewModel.initialize(organizationId)
-        val selectedIcon = ImageOptionUIModel(
-            id = "custom_local",
-            displayName = "Custom Image",
-            imageSource = ImageSource.LocalFile(imageUri, "test.jpg")
-        )
-        viewModel.addProperty(propertyName, address, selectedIcon)
-        verificationJob.join()
 
         // Assert
         coVerify(exactly = 1) {

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/employeeoverview/EmployeeOverviewViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/employeeoverview/EmployeeOverviewViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.cramsan.edifikana.client.lib.features.home.employeeoverview
 
-import app.cash.turbine.test
+import app.cash.turbine.turbineScope
+import com.cramsan.framework.test.advanceUntilIdleAndAwaitComplete
 import com.cramsan.edifikana.client.lib.features.home.HomeDestination
 import com.cramsan.edifikana.client.lib.features.window.EdifikanaWindowsEvent
 import com.cramsan.edifikana.client.lib.managers.AuthManager
@@ -24,7 +25,6 @@ import com.cramsan.framework.test.CoroutineTest
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import kotlinx.coroutines.launch
 import org.junit.jupiter.api.BeforeEach
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -201,17 +201,15 @@ class EmployeeOverviewViewModelTest : CoroutineTest() {
         coEvery { authManager.getUsers(organizationId) } returns Result.failure(Exception("Network error"))
         coEvery { authManager.getInvites(organizationId) } returns Result.success(emptyList())
 
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.ShowSnackbar("Failed to load employees: Network error"),
-                    awaitItem()
-                )
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.setOrgId(organizationId)
+            assertEquals(
+                EdifikanaWindowsEvent.ShowSnackbar("Failed to load employees: Network error"),
+                turbine.awaitItem()
+            )
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        viewModel.setOrgId(organizationId)
-        verificationJob.join()
 
         assertEquals(false, viewModel.uiState.value.isLoading)
         assertEquals(emptyList(), viewModel.uiState.value.employeeList)
@@ -224,17 +222,15 @@ class EmployeeOverviewViewModelTest : CoroutineTest() {
         coEvery { authManager.getUsers(organizationId) } returns Result.success(emptyList())
         coEvery { authManager.getInvites(organizationId) } returns Result.failure(Exception("Server error"))
 
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.ShowSnackbar("Failed to load invites: Server error"),
-                    awaitItem()
-                )
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.setOrgId(organizationId)
+            assertEquals(
+                EdifikanaWindowsEvent.ShowSnackbar("Failed to load invites: Server error"),
+                turbine.awaitItem()
+            )
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        viewModel.setOrgId(organizationId)
-        verificationJob.join()
 
         assertEquals(false, viewModel.uiState.value.isLoading)
         assertEquals(emptyList(), viewModel.uiState.value.employeeList)
@@ -247,21 +243,19 @@ class EmployeeOverviewViewModelTest : CoroutineTest() {
         coEvery { authManager.getUsers(organizationId) } returns Result.failure(Exception("Users error"))
         coEvery { authManager.getInvites(organizationId) } returns Result.failure(Exception("Invites error"))
 
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.ShowSnackbar("Failed to load employees: Users error"),
-                    awaitItem()
-                )
-                assertEquals(
-                    EdifikanaWindowsEvent.ShowSnackbar("Failed to load invites: Invites error"),
-                    awaitItem()
-                )
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.setOrgId(organizationId)
+            assertEquals(
+                EdifikanaWindowsEvent.ShowSnackbar("Failed to load employees: Users error"),
+                turbine.awaitItem()
+            )
+            assertEquals(
+                EdifikanaWindowsEvent.ShowSnackbar("Failed to load invites: Invites error"),
+                turbine.awaitItem()
+            )
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        viewModel.setOrgId(organizationId)
-        verificationJob.join()
 
         assertEquals(false, viewModel.uiState.value.isLoading)
     }
@@ -282,17 +276,15 @@ class EmployeeOverviewViewModelTest : CoroutineTest() {
         coEvery { authManager.getUsers(organizationId) } returns Result.failure(Exception("Network error"))
         coEvery { authManager.getInvites(organizationId) } returns Result.success(invites)
 
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.ShowSnackbar("Failed to load employees: Network error"),
-                    awaitItem()
-                )
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.setOrgId(organizationId)
+            assertEquals(
+                EdifikanaWindowsEvent.ShowSnackbar("Failed to load employees: Network error"),
+                turbine.awaitItem()
+            )
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        viewModel.setOrgId(organizationId)
-        verificationJob.join()
 
         assertEquals(false, viewModel.uiState.value.isLoading)
         assertEquals(1, viewModel.uiState.value.employeeList.size)
@@ -317,17 +309,15 @@ class EmployeeOverviewViewModelTest : CoroutineTest() {
         coEvery { authManager.getUsers(organizationId) } returns Result.success(users)
         coEvery { authManager.getInvites(organizationId) } returns Result.failure(Exception("Server error"))
 
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.ShowSnackbar("Failed to load invites: Server error"),
-                    awaitItem()
-                )
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.setOrgId(organizationId)
+            assertEquals(
+                EdifikanaWindowsEvent.ShowSnackbar("Failed to load invites: Server error"),
+                turbine.awaitItem()
+            )
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        viewModel.setOrgId(organizationId)
-        verificationJob.join()
 
         assertEquals(false, viewModel.uiState.value.isLoading)
         assertEquals(1, viewModel.uiState.value.employeeList.size)
@@ -345,31 +335,27 @@ class EmployeeOverviewViewModelTest : CoroutineTest() {
 
         viewModel.setOrgId(organizationId)
 
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.NavigateToScreen(
-                        HomeDestination.InviteStaffMemberDestination(orgId = organizationId)
-                    ),
-                    awaitItem()
-                )
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.navigateToAddEmployeeScreen()
+            assertEquals(
+                EdifikanaWindowsEvent.NavigateToScreen(
+                    HomeDestination.InviteStaffMemberDestination(orgId = organizationId)
+                ),
+                turbine.awaitItem()
+            )
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        viewModel.navigateToAddEmployeeScreen()
-        verificationJob.join()
     }
 
     @Test
     fun `test navigateToAddEmployeeScreen without orgId does not emit event`() = runCoroutineTest {
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                expectNoEvents()
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.navigateToAddEmployeeScreen()
+            turbine.expectNoEvents()
+            turbine.cancel()
         }
-
-        viewModel.navigateToAddEmployeeScreen()
-        verificationJob.cancel()
 
         // No events should be emitted when orgId is null
     }

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/employeeoverview/EmployeeOverviewViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/employeeoverview/EmployeeOverviewViewModelTest.kt
@@ -202,8 +202,13 @@ class EmployeeOverviewViewModelTest : CoroutineTest() {
         coEvery { authManager.getInvites(organizationId) } returns Result.success(emptyList())
 
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.setOrgId(organizationId)
+
+            // Assert
             assertEquals(
                 EdifikanaWindowsEvent.ShowSnackbar("Failed to load employees: Network error"),
                 turbine.awaitItem()
@@ -223,8 +228,13 @@ class EmployeeOverviewViewModelTest : CoroutineTest() {
         coEvery { authManager.getInvites(organizationId) } returns Result.failure(Exception("Server error"))
 
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.setOrgId(organizationId)
+
+            // Assert
             assertEquals(
                 EdifikanaWindowsEvent.ShowSnackbar("Failed to load invites: Server error"),
                 turbine.awaitItem()
@@ -244,8 +254,13 @@ class EmployeeOverviewViewModelTest : CoroutineTest() {
         coEvery { authManager.getInvites(organizationId) } returns Result.failure(Exception("Invites error"))
 
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.setOrgId(organizationId)
+
+            // Assert
             assertEquals(
                 EdifikanaWindowsEvent.ShowSnackbar("Failed to load employees: Users error"),
                 turbine.awaitItem()
@@ -277,8 +292,13 @@ class EmployeeOverviewViewModelTest : CoroutineTest() {
         coEvery { authManager.getInvites(organizationId) } returns Result.success(invites)
 
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.setOrgId(organizationId)
+
+            // Assert
             assertEquals(
                 EdifikanaWindowsEvent.ShowSnackbar("Failed to load employees: Network error"),
                 turbine.awaitItem()
@@ -310,8 +330,13 @@ class EmployeeOverviewViewModelTest : CoroutineTest() {
         coEvery { authManager.getInvites(organizationId) } returns Result.failure(Exception("Server error"))
 
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.setOrgId(organizationId)
+
+            // Assert
             assertEquals(
                 EdifikanaWindowsEvent.ShowSnackbar("Failed to load invites: Server error"),
                 turbine.awaitItem()
@@ -336,8 +361,13 @@ class EmployeeOverviewViewModelTest : CoroutineTest() {
         viewModel.setOrgId(organizationId)
 
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.navigateToAddEmployeeScreen()
+
+            // Assert
             assertEquals(
                 EdifikanaWindowsEvent.NavigateToScreen(
                     HomeDestination.InviteStaffMemberDestination(orgId = organizationId)
@@ -351,8 +381,13 @@ class EmployeeOverviewViewModelTest : CoroutineTest() {
     @Test
     fun `test navigateToAddEmployeeScreen without orgId does not emit event`() = runCoroutineTest {
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.navigateToAddEmployeeScreen()
+
+            // Assert
             turbine.expectNoEvents()
             turbine.cancel()
         }

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/gotoorganization/GoToOrganizationViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/gotoorganization/GoToOrganizationViewModelTest.kt
@@ -61,10 +61,14 @@ class GoToOrganizationViewModelTest : CoroutineTest() {
 
     @Test
     fun `test events`() = runCoroutineTest {
-        // Set up & Act
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.onBackSelected()
+
+            // Assert
             assertEquals(EdifikanaWindowsEvent.NavigateBack, turbine.awaitItem())
             advanceUntilIdleAndAwaitComplete(turbine)
         }

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/gotoorganization/GoToOrganizationViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/gotoorganization/GoToOrganizationViewModelTest.kt
@@ -1,6 +1,6 @@
 package com.cramsan.edifikana.client.lib.features.home.gotoorganization
 
-import app.cash.turbine.test
+import app.cash.turbine.turbineScope
 import com.cramsan.edifikana.client.lib.features.home.gotoorganization.GoToOrganizationViewModel
 import com.cramsan.edifikana.client.lib.features.window.EdifikanaWindowsEvent
 import com.cramsan.framework.core.UnifiedDispatcherProvider
@@ -16,7 +16,6 @@ import com.cramsan.framework.test.CollectorCoroutineExceptionHandler
 import com.cramsan.framework.test.CoroutineTest
 import com.cramsan.framework.test.advanceUntilIdleAndAwaitComplete
 import io.mockk.mockk
-import kotlinx.coroutines.launch
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -62,18 +61,12 @@ class GoToOrganizationViewModelTest : CoroutineTest() {
 
     @Test
     fun `test events`() = runCoroutineTest {
-        // Set up
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(EdifikanaWindowsEvent.NavigateBack, awaitItem())
-                advanceUntilIdleAndAwaitComplete(this)
-            }
+        // Set up & Act
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.onBackSelected()
+            assertEquals(EdifikanaWindowsEvent.NavigateBack, turbine.awaitItem())
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        // Act
-        viewModel.onBackSelected()
-
-        // Assert
-        verificationJob.join()
     }
 }

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/home/HomeViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/home/HomeViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.cramsan.edifikana.client.lib.features.home.home
 
-import app.cash.turbine.test
+import app.cash.turbine.turbineScope
+import com.cramsan.framework.test.advanceUntilIdleAndAwaitComplete
 import com.cramsan.architecture.client.manager.PreferencesManager
 import com.cramsan.edifikana.client.lib.features.account.AccountDestination
 import com.cramsan.edifikana.client.lib.features.home.propertyhome.PropertyHomeViewModel
@@ -26,7 +27,6 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.launch
 import org.junit.jupiter.api.BeforeEach
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -108,56 +108,44 @@ class HomeViewModelTest : CoroutineTest() {
 
     @Test
     fun `test navigateBack emits NavigateBack event`() = runCoroutineTest {
-        // Act
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.NavigateBack,
-                    awaitItem(),
-                )
-            }
+        // Act & Assert
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.navigateBack()
+            assertEquals(EdifikanaWindowsEvent.NavigateBack, turbine.awaitItem())
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-        viewModel.navigateBack()
-
-        // Assert
-        verificationJob.join()
     }
 
     @Test
     fun `test navigateToAccount emits NavigateToNavGraph event`() = runCoroutineTest {
-        // Act
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.NavigateToNavGraph(
-                        EdifikanaNavGraphDestination.AccountNavGraphDestination
-                    ),
-                    awaitItem(),
-                )
-            }
+        // Act & Assert
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.navigateToAccount()
+            assertEquals(
+                EdifikanaWindowsEvent.NavigateToNavGraph(
+                    EdifikanaNavGraphDestination.AccountNavGraphDestination
+                ),
+                turbine.awaitItem(),
+            )
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-        viewModel.navigateToAccount()
-
-        // Assert
-        verificationJob.join()
     }
 
     @Test
     fun `test navigateToNotifications emits NavigateToScreen event`() = runCoroutineTest {
-        // Act
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.NavigateToScreen(
-                        AccountDestination.NotificationsDestination
-                    ),
-                    awaitItem(),
-                )
-            }
+        // Act & Assert
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.navigateToNotifications()
+            assertEquals(
+                EdifikanaWindowsEvent.NavigateToScreen(
+                    AccountDestination.NotificationsDestination
+                ),
+                turbine.awaitItem(),
+            )
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-        viewModel.navigateToNotifications()
-
-        // Assert
-        verificationJob.join()
     }
 }

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/home/HomeViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/home/HomeViewModelTest.kt
@@ -108,10 +108,14 @@ class HomeViewModelTest : CoroutineTest() {
 
     @Test
     fun `test navigateBack emits NavigateBack event`() = runCoroutineTest {
-        // Act & Assert
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.navigateBack()
+
+            // Assert
             assertEquals(EdifikanaWindowsEvent.NavigateBack, turbine.awaitItem())
             advanceUntilIdleAndAwaitComplete(turbine)
         }
@@ -119,10 +123,14 @@ class HomeViewModelTest : CoroutineTest() {
 
     @Test
     fun `test navigateToAccount emits NavigateToNavGraph event`() = runCoroutineTest {
-        // Act & Assert
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.navigateToAccount()
+
+            // Assert
             assertEquals(
                 EdifikanaWindowsEvent.NavigateToNavGraph(
                     EdifikanaNavGraphDestination.AccountNavGraphDestination
@@ -135,10 +143,14 @@ class HomeViewModelTest : CoroutineTest() {
 
     @Test
     fun `test navigateToNotifications emits NavigateToScreen event`() = runCoroutineTest {
-        // Act & Assert
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.navigateToNotifications()
+
+            // Assert
             assertEquals(
                 EdifikanaWindowsEvent.NavigateToScreen(
                     AccountDestination.NotificationsDestination

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/hub/HubViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/hub/HubViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.cramsan.edifikana.client.lib.features.home.hub
 
-import app.cash.turbine.test
+import app.cash.turbine.turbineScope
+import com.cramsan.framework.test.advanceUntilIdleAndAwaitComplete
 import com.cramsan.architecture.client.manager.PreferencesManager
 import com.cramsan.edifikana.client.lib.features.account.AccountDestination
 import com.cramsan.edifikana.client.lib.features.home.organizationhome.OrganizationHomeViewModel
@@ -19,7 +20,6 @@ import com.cramsan.framework.logging.implementation.StdOutEventLoggerDelegate
 import com.cramsan.framework.test.CollectorCoroutineExceptionHandler
 import com.cramsan.framework.test.CoroutineTest
 import io.mockk.mockk
-import kotlinx.coroutines.launch
 import org.junit.jupiter.api.BeforeEach
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -56,16 +56,15 @@ class HubViewModelTest : CoroutineTest() {
 
     @Test
     fun `test navigateToAccount emits NavigateToNavGraph event`() = runCoroutineTest {
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.NavigateToNavGraph(EdifikanaNavGraphDestination.AccountNavGraphDestination),
-                    awaitItem()
-                )
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.navigateToAccount()
+            assertEquals(
+                EdifikanaWindowsEvent.NavigateToNavGraph(EdifikanaNavGraphDestination.AccountNavGraphDestination),
+                turbine.awaitItem()
+            )
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-        viewModel.navigateToAccount()
-        verificationJob.join()
     }
 
     @Test
@@ -77,15 +76,14 @@ class HubViewModelTest : CoroutineTest() {
 
     @Test
     fun `test navigateToNotifications emits NavigateToScreen event`() = runCoroutineTest {
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.NavigateToScreen(AccountDestination.NotificationsDestination),
-                    awaitItem()
-                )
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.navigateToNotifications()
+            assertEquals(
+                EdifikanaWindowsEvent.NavigateToScreen(AccountDestination.NotificationsDestination),
+                turbine.awaitItem()
+            )
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-        viewModel.navigateToNotifications()
-        verificationJob.join()
     }
 }

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/hub/HubViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/hub/HubViewModelTest.kt
@@ -57,8 +57,13 @@ class HubViewModelTest : CoroutineTest() {
     @Test
     fun `test navigateToAccount emits NavigateToNavGraph event`() = runCoroutineTest {
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.navigateToAccount()
+
+            // Assert
             assertEquals(
                 EdifikanaWindowsEvent.NavigateToNavGraph(EdifikanaNavGraphDestination.AccountNavGraphDestination),
                 turbine.awaitItem()
@@ -77,8 +82,13 @@ class HubViewModelTest : CoroutineTest() {
     @Test
     fun `test navigateToNotifications emits NavigateToScreen event`() = runCoroutineTest {
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.navigateToNotifications()
+
+            // Assert
             assertEquals(
                 EdifikanaWindowsEvent.NavigateToScreen(AccountDestination.NotificationsDestination),
                 turbine.awaitItem()

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/invitestaffmember/InviteStaffMemberViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/invitestaffmember/InviteStaffMemberViewModelTest.kt
@@ -70,8 +70,13 @@ class InviteStaffMemberViewModelTest : CoroutineTest() {
     @Test
     fun `test navigateBack emits NavigateBack event`() = runCoroutineTest {
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.navigateBack()
+
+            // Assert
             assertEquals(EdifikanaWindowsEvent.NavigateBack, turbine.awaitItem())
             advanceUntilIdleAndAwaitComplete(turbine)
         }
@@ -85,8 +90,13 @@ class InviteStaffMemberViewModelTest : CoroutineTest() {
         viewModel.initialize(organizationId)
 
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.sendInvitation("", role)
+
+            // Assert
             assertEquals(EdifikanaWindowsEvent.ShowSnackbar("Email cannot be empty."), turbine.awaitItem())
             advanceUntilIdleAndAwaitComplete(turbine)
         }
@@ -102,8 +112,13 @@ class InviteStaffMemberViewModelTest : CoroutineTest() {
         viewModel.initialize(organizationId)
 
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.sendInvitation("   ", role)
+
+            // Assert
             assertEquals(EdifikanaWindowsEvent.ShowSnackbar("Email cannot be empty."), turbine.awaitItem())
             advanceUntilIdleAndAwaitComplete(turbine)
         }
@@ -119,8 +134,13 @@ class InviteStaffMemberViewModelTest : CoroutineTest() {
         viewModel.initialize(organizationId)
 
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.sendInvitation("invalid-email", role)
+
+            // Assert
             assertEquals(EdifikanaWindowsEvent.ShowSnackbar("Invalid email format."), turbine.awaitItem())
             advanceUntilIdleAndAwaitComplete(turbine)
         }
@@ -136,8 +156,13 @@ class InviteStaffMemberViewModelTest : CoroutineTest() {
         viewModel.initialize(organizationId)
 
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.sendInvitation(email, null)
+
+            // Assert
             assertEquals(EdifikanaWindowsEvent.ShowSnackbar("Please select a role"), turbine.awaitItem())
             advanceUntilIdleAndAwaitComplete(turbine)
         }
@@ -156,8 +181,13 @@ class InviteStaffMemberViewModelTest : CoroutineTest() {
         viewModel.initialize(organizationId)
 
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.sendInvitation(email, role)
+
+            // Assert
             assertEquals(EdifikanaWindowsEvent.ShowSnackbar("Invitation sent to $email"), turbine.awaitItem())
             assertEquals(EdifikanaWindowsEvent.NavigateBack, turbine.awaitItem())
             advanceUntilIdleAndAwaitComplete(turbine)
@@ -180,8 +210,13 @@ class InviteStaffMemberViewModelTest : CoroutineTest() {
         viewModel.initialize(organizationId)
 
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.sendInvitation(email, role)
+
+            // Assert
             assertEquals(EdifikanaWindowsEvent.ShowSnackbar("Failed to send invitation"), turbine.awaitItem())
             advanceUntilIdleAndAwaitComplete(turbine)
         }

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/invitestaffmember/InviteStaffMemberViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/invitestaffmember/InviteStaffMemberViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.cramsan.edifikana.client.lib.features.home.invitestaffmember
 
-import app.cash.turbine.test
+import app.cash.turbine.turbineScope
+import com.cramsan.framework.test.advanceUntilIdleAndAwaitComplete
 import com.cramsan.edifikana.client.lib.features.window.EdifikanaWindowsEvent
 import com.cramsan.edifikana.client.lib.managers.AuthManager
 import com.cramsan.edifikana.lib.model.OrganizationId
@@ -18,7 +19,6 @@ import com.cramsan.framework.test.CoroutineTest
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import kotlinx.coroutines.launch
 import org.junit.jupiter.api.BeforeEach
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -69,16 +69,12 @@ class InviteStaffMemberViewModelTest : CoroutineTest() {
 
     @Test
     fun `test navigateBack emits NavigateBack event`() = runCoroutineTest {
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.NavigateBack,
-                    awaitItem()
-                )
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.navigateBack()
+            assertEquals(EdifikanaWindowsEvent.NavigateBack, turbine.awaitItem())
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-        viewModel.navigateBack()
-        verificationJob.join()
     }
 
     @Test
@@ -88,17 +84,12 @@ class InviteStaffMemberViewModelTest : CoroutineTest() {
 
         viewModel.initialize(organizationId)
 
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.ShowSnackbar("Email cannot be empty."),
-                    awaitItem()
-                )
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.sendInvitation("", role)
+            assertEquals(EdifikanaWindowsEvent.ShowSnackbar("Email cannot be empty."), turbine.awaitItem())
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        viewModel.sendInvitation("", role)
-        verificationJob.join()
 
         coVerify(exactly = 0) { authManager.inviteEmployee(any(), any(), any()) }
     }
@@ -110,17 +101,12 @@ class InviteStaffMemberViewModelTest : CoroutineTest() {
 
         viewModel.initialize(organizationId)
 
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.ShowSnackbar("Email cannot be empty."),
-                    awaitItem()
-                )
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.sendInvitation("   ", role)
+            assertEquals(EdifikanaWindowsEvent.ShowSnackbar("Email cannot be empty."), turbine.awaitItem())
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        viewModel.sendInvitation("   ", role)
-        verificationJob.join()
 
         coVerify(exactly = 0) { authManager.inviteEmployee(any(), any(), any()) }
     }
@@ -132,17 +118,12 @@ class InviteStaffMemberViewModelTest : CoroutineTest() {
 
         viewModel.initialize(organizationId)
 
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.ShowSnackbar("Invalid email format."),
-                    awaitItem()
-                )
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.sendInvitation("invalid-email", role)
+            assertEquals(EdifikanaWindowsEvent.ShowSnackbar("Invalid email format."), turbine.awaitItem())
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        viewModel.sendInvitation("invalid-email", role)
-        verificationJob.join()
 
         coVerify(exactly = 0) { authManager.inviteEmployee(any(), any(), any()) }
     }
@@ -154,17 +135,12 @@ class InviteStaffMemberViewModelTest : CoroutineTest() {
 
         viewModel.initialize(organizationId)
 
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.ShowSnackbar("Please select a role"),
-                    awaitItem()
-                )
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.sendInvitation(email, null)
+            assertEquals(EdifikanaWindowsEvent.ShowSnackbar("Please select a role"), turbine.awaitItem())
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        viewModel.sendInvitation(email, null)
-        verificationJob.join()
 
         coVerify(exactly = 0) { authManager.inviteEmployee(any(), any(), any()) }
     }
@@ -179,18 +155,13 @@ class InviteStaffMemberViewModelTest : CoroutineTest() {
 
         viewModel.initialize(organizationId)
 
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.ShowSnackbar("Invitation sent to $email"),
-                    awaitItem()
-                )
-                assertEquals(EdifikanaWindowsEvent.NavigateBack, awaitItem())
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.sendInvitation(email, role)
+            assertEquals(EdifikanaWindowsEvent.ShowSnackbar("Invitation sent to $email"), turbine.awaitItem())
+            assertEquals(EdifikanaWindowsEvent.NavigateBack, turbine.awaitItem())
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        viewModel.sendInvitation(email, role)
-        verificationJob.join()
 
         coVerify { authManager.inviteEmployee(email, organizationId, UserRole.ADMIN) }
         assertTrue(exceptionHandler.exceptions.isEmpty())
@@ -208,17 +179,12 @@ class InviteStaffMemberViewModelTest : CoroutineTest() {
 
         viewModel.initialize(organizationId)
 
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.ShowSnackbar("Failed to send invitation"),
-                    awaitItem()
-                )
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.sendInvitation(email, role)
+            assertEquals(EdifikanaWindowsEvent.ShowSnackbar("Failed to send invitation"), turbine.awaitItem())
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        viewModel.sendInvitation(email, role)
-        verificationJob.join()
 
         coVerify { authManager.inviteEmployee(email, organizationId, UserRole.ADMIN) }
         assertEquals(false, viewModel.uiState.value.isLoading)

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/propertiesoverview/PropertiesOverviewViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/propertiesoverview/PropertiesOverviewViewModelTest.kt
@@ -2,6 +2,7 @@ package com.cramsan.edifikana.client.lib.features.home.propertiesoverview
 
 import app.cash.turbine.test
 import app.cash.turbine.turbineScope
+import com.cramsan.framework.test.advanceUntilIdleAndAwaitComplete
 import com.cramsan.edifikana.client.lib.features.home.HomeDestination
 import com.cramsan.edifikana.client.lib.features.window.EdifikanaWindowsEvent
 import com.cramsan.edifikana.client.lib.managers.OrganizationManager
@@ -23,7 +24,6 @@ import com.cramsan.framework.test.CoroutineTest
 import com.cramsan.framework.test.advanceUntilIdleAndAwaitComplete
 import io.mockk.coEvery
 import io.mockk.mockk
-import kotlinx.coroutines.launch
 import org.junit.jupiter.api.assertInstanceOf
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -130,17 +130,14 @@ class PropertiesOverviewViewModelTest : CoroutineTest() {
     fun `test onAddPropertySelected with no organizations emits snackbar`() = runCoroutineTest {
         // Set up
         coEvery { organizationManager.getOrganizations() } returns Result.success(emptyList())
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertInstanceOf<EdifikanaWindowsEvent.ShowSnackbar>(awaitItem())
-            }
+
+        // Act & Assert
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.onAddPropertySelected()
+            assertInstanceOf<EdifikanaWindowsEvent.ShowSnackbar>(turbine.awaitItem())
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        // Act
-        viewModel.onAddPropertySelected()
-
-        // Assert
-        verificationJob.join()
     }
 
     @Test

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/propertiesoverview/PropertiesOverviewViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/propertiesoverview/PropertiesOverviewViewModelTest.kt
@@ -109,7 +109,7 @@ class PropertiesOverviewViewModelTest : CoroutineTest() {
     @Test
     fun `test initialize handles failure and emits snackbar`() = runCoroutineTest {
         turbineScope {
-            // Set up
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
             val error = RuntimeException("Network error")
             coEvery { propertyManager.getPropertyList() } returns Result.failure(error)
@@ -131,10 +131,14 @@ class PropertiesOverviewViewModelTest : CoroutineTest() {
         // Set up
         coEvery { organizationManager.getOrganizations() } returns Result.success(emptyList())
 
-        // Act & Assert
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.onAddPropertySelected()
+
+            // Assert
             assertInstanceOf<EdifikanaWindowsEvent.ShowSnackbar>(turbine.awaitItem())
             advanceUntilIdleAndAwaitComplete(turbine)
         }
@@ -152,7 +156,10 @@ class PropertiesOverviewViewModelTest : CoroutineTest() {
 
         // Act & Assert
         windowEventBus.events.test {
+            // Act
             viewModel.onAddPropertySelected()
+
+            // Assert
             val event = awaitItem()
             assertEquals(true, event is EdifikanaWindowsEvent.NavigateToScreen)
             val navEvent = event as? EdifikanaWindowsEvent.NavigateToScreen

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/propertydetail/PropertyDetailViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/propertydetail/PropertyDetailViewModelTest.kt
@@ -26,7 +26,6 @@ import com.cramsan.framework.test.CoroutineTest
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import kotlinx.coroutines.launch
 import org.junit.jupiter.api.BeforeEach
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -108,16 +107,14 @@ class PropertyDetailViewModelTest : CoroutineTest() {
             Exception("Network error")
         )
 
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                val event = awaitItem() as EdifikanaWindowsEvent.ShowSnackbar
-                assertTrue(event.message.contains("Failed to load property"))
-                assertTrue(event.message.contains("Network error"))
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.initialize(propertyId)
+            val event = turbine.awaitItem() as EdifikanaWindowsEvent.ShowSnackbar
+            assertTrue(event.message.contains("Failed to load property"))
+            assertTrue(event.message.contains("Network error"))
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        viewModel.initialize(propertyId)
-        verificationJob.join()
 
         assertFalse(viewModel.uiState.value.isLoading)
         coVerify { propertyManager.getProperty(propertyId) }
@@ -125,13 +122,12 @@ class PropertyDetailViewModelTest : CoroutineTest() {
 
     @Test
     fun `test navigateBack emits NavigateBack event`() = runCoroutineTest {
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(EdifikanaWindowsEvent.NavigateBack, awaitItem())
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.navigateBack()
+            assertEquals(EdifikanaWindowsEvent.NavigateBack, turbine.awaitItem())
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-        viewModel.navigateBack()
-        verificationJob.join()
     }
 
     @Test
@@ -274,15 +270,13 @@ class PropertyDetailViewModelTest : CoroutineTest() {
         viewModel.initialize(propertyId)
         viewModel.toggleEditMode()
 
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                val event = awaitItem() as EdifikanaWindowsEvent.ShowSnackbar
-                assertTrue(event.message.contains("Failed to update property"))
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.saveProperty()
+            val event = turbine.awaitItem() as EdifikanaWindowsEvent.ShowSnackbar
+            assertTrue(event.message.contains("Failed to update property"))
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        viewModel.saveProperty()
-        verificationJob.join()
 
         assertFalse(viewModel.uiState.value.isLoading)
     }
@@ -309,16 +303,14 @@ class PropertyDetailViewModelTest : CoroutineTest() {
 
         viewModel.initialize(propertyId)
 
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                val snackbarEvent = awaitItem() as EdifikanaWindowsEvent.ShowSnackbar
-                assertEquals("Property deleted successfully", snackbarEvent.message)
-                assertEquals(EdifikanaWindowsEvent.NavigateBack, awaitItem())
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.deleteProperty()
+            val snackbarEvent = turbine.awaitItem() as EdifikanaWindowsEvent.ShowSnackbar
+            assertEquals("Property deleted successfully", snackbarEvent.message)
+            assertEquals(EdifikanaWindowsEvent.NavigateBack, turbine.awaitItem())
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        viewModel.deleteProperty()
-        verificationJob.join()
 
         coVerify { propertyManager.removeProperty(propertyId) }
         assertTrue(exceptionHandler.exceptions.isEmpty())
@@ -341,16 +333,14 @@ class PropertyDetailViewModelTest : CoroutineTest() {
 
         viewModel.initialize(propertyId)
 
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                val event = awaitItem() as EdifikanaWindowsEvent.ShowSnackbar
-                assertTrue(event.message.contains("Failed to delete property"))
-                assertTrue(event.message.contains("Delete failed"))
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.deleteProperty()
+            val event = turbine.awaitItem() as EdifikanaWindowsEvent.ShowSnackbar
+            assertTrue(event.message.contains("Failed to delete property"))
+            assertTrue(event.message.contains("Delete failed"))
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        viewModel.deleteProperty()
-        verificationJob.join()
 
         assertFalse(viewModel.uiState.value.isLoading)
     }

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/propertydetail/PropertyDetailViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/propertydetail/PropertyDetailViewModelTest.kt
@@ -23,6 +23,7 @@ import com.cramsan.framework.logging.implementation.PassthroughEventLogger
 import com.cramsan.framework.logging.implementation.StdOutEventLoggerDelegate
 import com.cramsan.framework.test.CollectorCoroutineExceptionHandler
 import com.cramsan.framework.test.CoroutineTest
+import com.cramsan.framework.test.advanceUntilIdleAndAwaitComplete
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -213,6 +214,7 @@ class PropertyDetailViewModelTest : CoroutineTest() {
     @Test
     fun `test saveProperty with success updates property and shows success message`() = runCoroutineTest {
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
             val propertyId = PropertyId("test-property-id")
             val property = PropertyModel(
@@ -244,9 +246,6 @@ class PropertyDetailViewModelTest : CoroutineTest() {
                 imageSource = ImageSource.Drawable(PropertyIcons.M_DEPA),
             ))
 
-        turbineScope {
-            // Arrange
-            val turbine = windowEventBus.events.testIn(backgroundScope)
 
             // Act
             viewModel.saveProperty()

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/propertydetail/PropertyDetailViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/propertydetail/PropertyDetailViewModelTest.kt
@@ -108,8 +108,13 @@ class PropertyDetailViewModelTest : CoroutineTest() {
         )
 
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.initialize(propertyId)
+
+            // Assert
             val event = turbine.awaitItem() as EdifikanaWindowsEvent.ShowSnackbar
             assertTrue(event.message.contains("Failed to load property"))
             assertTrue(event.message.contains("Network error"))
@@ -123,8 +128,13 @@ class PropertyDetailViewModelTest : CoroutineTest() {
     @Test
     fun `test navigateBack emits NavigateBack event`() = runCoroutineTest {
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.navigateBack()
+
+            // Assert
             assertEquals(EdifikanaWindowsEvent.NavigateBack, turbine.awaitItem())
             advanceUntilIdleAndAwaitComplete(turbine)
         }
@@ -234,8 +244,14 @@ class PropertyDetailViewModelTest : CoroutineTest() {
                 imageSource = ImageSource.Drawable(PropertyIcons.M_DEPA),
             ))
 
+        turbineScope {
+            // Arrange
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.saveProperty()
 
+            // Assert
             val event = turbine.awaitItem() as EdifikanaWindowsEvent.ShowSnackbar
             assertEquals("Property updated successfully", event.message)
             assertFalse(viewModel.uiState.value.isLoading)
@@ -271,8 +287,13 @@ class PropertyDetailViewModelTest : CoroutineTest() {
         viewModel.toggleEditMode()
 
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.saveProperty()
+
+            // Assert
             val event = turbine.awaitItem() as EdifikanaWindowsEvent.ShowSnackbar
             assertTrue(event.message.contains("Failed to update property"))
             advanceUntilIdleAndAwaitComplete(turbine)
@@ -304,8 +325,13 @@ class PropertyDetailViewModelTest : CoroutineTest() {
         viewModel.initialize(propertyId)
 
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.deleteProperty()
+
+            // Assert
             val snackbarEvent = turbine.awaitItem() as EdifikanaWindowsEvent.ShowSnackbar
             assertEquals("Property deleted successfully", snackbarEvent.message)
             assertEquals(EdifikanaWindowsEvent.NavigateBack, turbine.awaitItem())
@@ -334,8 +360,13 @@ class PropertyDetailViewModelTest : CoroutineTest() {
         viewModel.initialize(propertyId)
 
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.deleteProperty()
+
+            // Assert
             val event = turbine.awaitItem() as EdifikanaWindowsEvent.ShowSnackbar
             assertTrue(event.message.contains("Failed to delete property"))
             assertTrue(event.message.contains("Delete failed"))

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/propertyhome/PropertyHomeViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/propertyhome/PropertyHomeViewModelTest.kt
@@ -146,8 +146,13 @@ class PropertyHomeViewModelTest : CoroutineTest() {
     @Test
     fun `test navigateBack emits NavigateBack event`() = runCoroutineTest {
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.navigateBack()
+
+            // Assert
             assertEquals(EdifikanaWindowsEvent.NavigateBack, turbine.awaitItem())
             advanceUntilIdleAndAwaitComplete(turbine)
         }
@@ -156,8 +161,13 @@ class PropertyHomeViewModelTest : CoroutineTest() {
     @Test
     fun `test navigateToAccount emits NavigateToNavGraph event`() = runCoroutineTest {
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.navigateToAccount()
+
+            // Assert
             assertEquals(
                 EdifikanaWindowsEvent.NavigateToNavGraph(EdifikanaNavGraphDestination.AccountNavGraphDestination),
                 turbine.awaitItem()
@@ -169,8 +179,13 @@ class PropertyHomeViewModelTest : CoroutineTest() {
     @Test
     fun `test navigateToNotifications emits NavigateToScreen event`() = runCoroutineTest {
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.navigateToNotifications()
+
+            // Assert
             assertEquals(
                 EdifikanaWindowsEvent.NavigateToScreen(AccountDestination.NotificationsDestination),
                 turbine.awaitItem()
@@ -182,8 +197,13 @@ class PropertyHomeViewModelTest : CoroutineTest() {
     @Test
     fun `test navigateToSettings emits NavigateToNavGraph event`() = runCoroutineTest {
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.navigateToSettings()
+
+            // Assert
             assertEquals(
                 EdifikanaWindowsEvent.NavigateToNavGraph(EdifikanaNavGraphDestination.SettingsNavGraphDestination),
                 turbine.awaitItem()

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/propertyhome/PropertyHomeViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/home/propertyhome/PropertyHomeViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.cramsan.edifikana.client.lib.features.home.propertyhome
 
-import app.cash.turbine.test
+import app.cash.turbine.turbineScope
+import com.cramsan.framework.test.advanceUntilIdleAndAwaitComplete
 import com.cramsan.architecture.client.manager.PreferencesManager
 import com.cramsan.edifikana.client.lib.features.account.AccountDestination
 import com.cramsan.edifikana.client.lib.features.window.EdifikanaNavGraphDestination
@@ -22,7 +23,6 @@ import com.cramsan.framework.test.CoroutineTest
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import kotlinx.coroutines.launch
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -145,58 +145,51 @@ class PropertyHomeViewModelTest : CoroutineTest() {
 
     @Test
     fun `test navigateBack emits NavigateBack event`() = runCoroutineTest {
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.NavigateBack,
-                    awaitItem()
-                )
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.navigateBack()
+            assertEquals(EdifikanaWindowsEvent.NavigateBack, turbine.awaitItem())
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-        viewModel.navigateBack()
-        verificationJob.join()
     }
 
     @Test
     fun `test navigateToAccount emits NavigateToNavGraph event`() = runCoroutineTest {
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.NavigateToNavGraph(EdifikanaNavGraphDestination.AccountNavGraphDestination),
-                    awaitItem()
-                )
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.navigateToAccount()
+            assertEquals(
+                EdifikanaWindowsEvent.NavigateToNavGraph(EdifikanaNavGraphDestination.AccountNavGraphDestination),
+                turbine.awaitItem()
+            )
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-        viewModel.navigateToAccount()
-        verificationJob.join()
     }
 
     @Test
     fun `test navigateToNotifications emits NavigateToScreen event`() = runCoroutineTest {
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.NavigateToScreen(AccountDestination.NotificationsDestination),
-                    awaitItem()
-                )
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.navigateToNotifications()
+            assertEquals(
+                EdifikanaWindowsEvent.NavigateToScreen(AccountDestination.NotificationsDestination),
+                turbine.awaitItem()
+            )
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-        viewModel.navigateToNotifications()
-        verificationJob.join()
     }
 
     @Test
     fun `test navigateToSettings emits NavigateToNavGraph event`() = runCoroutineTest {
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(
-                    EdifikanaWindowsEvent.NavigateToNavGraph(EdifikanaNavGraphDestination.SettingsNavGraphDestination),
-                    awaitItem()
-                )
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.navigateToSettings()
+            assertEquals(
+                EdifikanaWindowsEvent.NavigateToNavGraph(EdifikanaNavGraphDestination.SettingsNavGraphDestination),
+                turbine.awaitItem()
+            )
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-        viewModel.navigateToSettings()
-        verificationJob.join()
     }
 
     @Test

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/settings/general/SettingsViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/settings/general/SettingsViewModelTest.kt
@@ -1,6 +1,6 @@
 package com.cramsan.edifikana.client.lib.features.settings.general
 
-import app.cash.turbine.test
+import app.cash.turbine.turbineScope
 import com.cramsan.architecture.client.manager.PreferencesManager
 import com.cramsan.architecture.client.settings.SettingKey
 import com.cramsan.edifikana.client.lib.settings.EdifikanaSettingKey
@@ -85,20 +85,19 @@ class SettingsViewModelTest : CoroutineTest() {
 
     @Test
     fun `navigateBack emits NavigateBack window event`() = runCoroutineTest {
-        // Set up turbine to listen to window events
-        val job = launch {
-            windowEventBus.events.test {
-                assertEquals(com.cramsan.edifikana.client.lib.features.window.EdifikanaWindowsEvent.NavigateBack, awaitItem())
-                // ensure collector drains
-                advanceUntilIdleAndAwaitComplete(this)
-            }
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
+            viewModel.navigateBack()
+
+            // Assert
+            assertEquals(
+                com.cramsan.edifikana.client.lib.features.window.EdifikanaWindowsEvent.NavigateBack,
+                turbine.awaitItem()
+            )
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        // Act
-        viewModel.navigateBack()
-
-        // Assert
-        job.join()
     }
 
     @Test

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/settings/general/SettingsViewModelTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/features/settings/general/SettingsViewModelTest.kt
@@ -86,6 +86,7 @@ class SettingsViewModelTest : CoroutineTest() {
     @Test
     fun `navigateBack emits NavigateBack window event`() = runCoroutineTest {
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
 
             // Act

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/managers/PreferencesManagerTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/managers/PreferencesManagerTest.kt
@@ -1,6 +1,7 @@
 package com.cramsan.edifikana.client.lib.managers
 
-import app.cash.turbine.test
+import app.cash.turbine.turbineScope
+import com.cramsan.framework.test.advanceUntilIdleAndAwaitComplete
 import com.cramsan.architecture.client.manager.PreferencesManager
 import com.cramsan.architecture.client.settings.FrontEndApplicationSettingKey
 import com.cramsan.architecture.client.settings.SettingsHolder
@@ -18,7 +19,6 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -74,15 +74,14 @@ class PreferencesManagerTest : CoroutineTest() {
 
         coEvery { settingsHolder.saveValue(key, value) } returns Unit
 
-        // collect the first emitted key from the flow using a CompletableDeferred and launch
-        val verificationJob = launch { manager.modifiedKey.test {
-            assertEquals(EdifikanaSettingKey.SupabaseOverrideUrl, awaitItem())
-        } }
-
-        manager.updatePreference(key, value)
+        turbineScope {
+            val turbine = manager.modifiedKey.testIn(backgroundScope)
+            manager.updatePreference(key, value)
+            assertEquals(EdifikanaSettingKey.SupabaseOverrideUrl, turbine.awaitItem())
+            advanceUntilIdleAndAwaitComplete(turbine)
+        }
 
         coVerify { settingsHolder.saveValue(key, value) }
-        verificationJob.join()
     }
 
     @Test

--- a/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/managers/PreferencesManagerTest.kt
+++ b/edifikana/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/edifikana/client/lib/managers/PreferencesManagerTest.kt
@@ -75,8 +75,13 @@ class PreferencesManagerTest : CoroutineTest() {
         coEvery { settingsHolder.saveValue(key, value) } returns Unit
 
         turbineScope {
+            // Arrange
             val turbine = manager.modifiedKey.testIn(backgroundScope)
+
+            // Act
             manager.updatePreference(key, value)
+
+            // Assert
             assertEquals(EdifikanaSettingKey.SupabaseOverrideUrl, turbine.awaitItem())
             advanceUntilIdleAndAwaitComplete(turbine)
         }

--- a/framework/core-compose/src/commonTest/kotlin/com/cramsan/framework/core/compose/BaseViewModelTest.kt
+++ b/framework/core-compose/src/commonTest/kotlin/com/cramsan/framework/core/compose/BaseViewModelTest.kt
@@ -1,6 +1,6 @@
 package com.cramsan.framework.core.compose
 
-import app.cash.turbine.test
+import app.cash.turbine.turbineScope
 import com.cramsan.framework.assertlib.AssertUtil
 import com.cramsan.framework.assertlib.implementation.NoopAssertUtil
 import com.cramsan.framework.core.UnifiedDispatcherProvider
@@ -10,7 +10,6 @@ import com.cramsan.framework.logging.implementation.StdOutEventLoggerDelegate
 import com.cramsan.framework.test.CollectorCoroutineExceptionHandler
 import com.cramsan.framework.test.CoroutineTest
 import com.cramsan.framework.test.advanceUntilIdleAndAwaitComplete
-import kotlinx.coroutines.launch
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -62,32 +61,24 @@ class BaseViewModelTest : CoroutineTest() {
 
     @Test
     fun `test emitting some numbers`() = runCoroutineTest {
-        val verificationJob = launch {
-            viewModel.events.test {
-                assertEquals(TestableEvent.EmitNumber(1), awaitItem())
-                assertEquals(TestableEvent.EmitNumber(2), awaitItem())
-                assertEquals(TestableEvent.EmitNumber(3), awaitItem())
-                advanceUntilIdleAndAwaitComplete(this)
-            }
+        turbineScope {
+            val turbine = viewModel.events.testIn(backgroundScope)
+            viewModel.emitNumbers()
+            assertEquals(TestableEvent.EmitNumber(1), turbine.awaitItem())
+            assertEquals(TestableEvent.EmitNumber(2), turbine.awaitItem())
+            assertEquals(TestableEvent.EmitNumber(3), turbine.awaitItem())
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        viewModel.emitNumbers()
-
-        verificationJob.join()
     }
 
     @Test
     fun `test emitting an application event`() = runCoroutineTest {
-        val verificationJob = launch {
-            windowEventReceiver.events.test {
-                assertEquals(TestableApplicationEvent.Signal, awaitItem())
-                advanceUntilIdleAndAwaitComplete(this)
-            }
+        turbineScope {
+            val turbine = windowEventReceiver.events.testIn(backgroundScope)
+            viewModel.emitApplicationEvent()
+            assertEquals(TestableApplicationEvent.Signal, turbine.awaitItem())
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        viewModel.emitApplicationEvent()
-
-        verificationJob.join()
     }
 
     @Test

--- a/framework/core-compose/src/commonTest/kotlin/com/cramsan/framework/core/compose/BaseViewModelTest.kt
+++ b/framework/core-compose/src/commonTest/kotlin/com/cramsan/framework/core/compose/BaseViewModelTest.kt
@@ -62,8 +62,13 @@ class BaseViewModelTest : CoroutineTest() {
     @Test
     fun `test emitting some numbers`() = runCoroutineTest {
         turbineScope {
+            // Arrange
             val turbine = viewModel.events.testIn(backgroundScope)
+
+            // Act
             viewModel.emitNumbers()
+
+            // Assert
             assertEquals(TestableEvent.EmitNumber(1), turbine.awaitItem())
             assertEquals(TestableEvent.EmitNumber(2), turbine.awaitItem())
             assertEquals(TestableEvent.EmitNumber(3), turbine.awaitItem())
@@ -74,8 +79,13 @@ class BaseViewModelTest : CoroutineTest() {
     @Test
     fun `test emitting an application event`() = runCoroutineTest {
         turbineScope {
+            // Arrange
             val turbine = windowEventReceiver.events.testIn(backgroundScope)
+
+            // Act
             viewModel.emitApplicationEvent()
+
+            // Assert
             assertEquals(TestableApplicationEvent.Signal, turbine.awaitItem())
             advanceUntilIdleAndAwaitComplete(turbine)
         }

--- a/runasimi/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/runasimi/client/lib/features/main/menu/MenuViewModelTest.kt
+++ b/runasimi/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/runasimi/client/lib/features/main/menu/MenuViewModelTest.kt
@@ -1,6 +1,6 @@
 package com.cramsan.runasimi.client.lib.features.main.menu
 
-import app.cash.turbine.test
+import app.cash.turbine.turbineScope
 import com.cramsan.architecture.client.manager.PreferencesManager
 import com.cramsan.framework.core.UnifiedDispatcherProvider
 import com.cramsan.framework.core.compose.ApplicationEvent
@@ -17,7 +17,6 @@ import com.cramsan.framework.test.advanceUntilIdleAndAwaitComplete
 import com.cramsan.runasimi.client.lib.features.main.menu.MenuViewModel
 import com.cramsan.runasimi.client.lib.features.window.RunasimiWindowsEvent
 import io.mockk.mockk
-import kotlinx.coroutines.launch
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -72,18 +71,12 @@ class MenuViewModelTest : CoroutineTest() {
 
     @Test
     fun `test events`() = runCoroutineTest {
-        // Set up
-        val verificationJob = launch {
-            windowEventBus.events.test {
-                assertEquals(RunasimiWindowsEvent.NavigateBack, awaitItem())
-                advanceUntilIdleAndAwaitComplete(this)
-            }
+        // Set up & Act
+        turbineScope {
+            val turbine = windowEventBus.events.testIn(backgroundScope)
+            viewModel.onBackSelected()
+            assertEquals(RunasimiWindowsEvent.NavigateBack, turbine.awaitItem())
+            advanceUntilIdleAndAwaitComplete(turbine)
         }
-
-        // Act
-        viewModel.onBackSelected()
-
-        // Assert
-        verificationJob.join()
     }
 }

--- a/runasimi/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/runasimi/client/lib/features/main/menu/MenuViewModelTest.kt
+++ b/runasimi/front-end/shared-app/src/jvmTest/kotlin/com/cramsan/runasimi/client/lib/features/main/menu/MenuViewModelTest.kt
@@ -71,10 +71,14 @@ class MenuViewModelTest : CoroutineTest() {
 
     @Test
     fun `test events`() = runCoroutineTest {
-        // Set up & Act
         turbineScope {
+            // Arrange
             val turbine = windowEventBus.events.testIn(backgroundScope)
+
+            // Act
             viewModel.onBackSelected()
+
+            // Assert
             assertEquals(RunasimiWindowsEvent.NavigateBack, turbine.awaitItem())
             advanceUntilIdleAndAwaitComplete(turbine)
         }


### PR DESCRIPTION
Fixes #379 

This change implements the migration away from verifying event emission by using:
```
val verificationJob = launch {
            windowEventBus.events.test {
                assertEquals(
                    EdifikanaWindowsEvent.NavigateToNavGraph(
                        EdifikanaNavGraphDestination.AuthNavGraphDestination,
                        clearStack = true,
                    ),
                    awaitItem(),
                )
            }
```

Now the changes will be in a `turbineScope` and that will allow us to assert on the emitted values:
```
turbineScope {
      // Arrange
      val turbine = windowEventBus.events.testIn(backgroundScope)

      // Act
      ...
      ...

      // Assert
      assertEquals(
           EdifikanaWindowsEvent.NavigateBack,
           turbine.awaitItem()
      )
```