### PR TITLE
[MDL] Add shared models for units and common areas

### DIFF
--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/CommonAreaId.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/CommonAreaId.kt
@@ -1,0 +1,14 @@
+package com.cramsan.edifikana.lib.model
+
+import com.cramsan.framework.annotations.api.PathParam
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmInline
+
+/**
+ * Domain model representing a common area ID.
+ */
+@JvmInline
+@Serializable
+value class CommonAreaId(val commonAreaId: String) : PathParam {
+    override fun toString(): String = commonAreaId
+}

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/CommonAreaType.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/CommonAreaType.kt
@@ -1,0 +1,44 @@
+package com.cramsan.edifikana.lib.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents the type of a common area within a property.
+ */
+@Serializable
+enum class CommonAreaType {
+    @SerialName("LOBBY")
+    LOBBY,
+    @SerialName("POOL")
+    POOL,
+    @SerialName("GYM")
+    GYM,
+    @SerialName("PARKING")
+    PARKING,
+    @SerialName("LAUNDRY")
+    LAUNDRY,
+    @SerialName("ROOFTOP")
+    ROOFTOP,
+    @SerialName("OTHER")
+    OTHER,
+    ;
+
+    companion object {
+        /**
+         * Converts a string value to a CommonAreaType.
+         */
+        fun fromString(value: String?): CommonAreaType {
+            return when (value) {
+                "LOBBY" -> LOBBY
+                "POOL" -> POOL
+                "GYM" -> GYM
+                "PARKING" -> PARKING
+                "LAUNDRY" -> LAUNDRY
+                "ROOFTOP" -> ROOFTOP
+                "OTHER" -> OTHER
+                else -> throw IllegalArgumentException("Invalid CommonAreaType value: $value")
+            }
+        }
+    }
+}

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/UnitId.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/UnitId.kt
@@ -1,0 +1,14 @@
+package com.cramsan.edifikana.lib.model
+
+import com.cramsan.framework.annotations.api.PathParam
+import kotlinx.serialization.Serializable
+import kotlin.jvm.JvmInline
+
+/**
+ * Domain model representing a unit ID.
+ */
+@JvmInline
+@Serializable
+value class UnitId(val unitId: String) : PathParam {
+    override fun toString(): String = unitId
+}

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/CommonAreaListNetworkResponse.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/CommonAreaListNetworkResponse.kt
@@ -1,0 +1,16 @@
+package com.cramsan.edifikana.lib.model.network
+
+import com.cramsan.framework.annotations.NetworkModel
+import com.cramsan.framework.annotations.api.ResponseBody
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Response model for a list of common areas.
+ */
+@NetworkModel
+@Serializable
+data class CommonAreaListNetworkResponse(
+    @SerialName("common_areas")
+    val commonAreas: List<CommonAreaNetworkResponse>,
+) : ResponseBody

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/CommonAreaNetworkResponse.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/CommonAreaNetworkResponse.kt
@@ -1,0 +1,29 @@
+package com.cramsan.edifikana.lib.model.network
+
+import com.cramsan.edifikana.lib.model.CommonAreaId
+import com.cramsan.edifikana.lib.model.OrganizationId
+import com.cramsan.edifikana.lib.model.PropertyId
+import com.cramsan.framework.annotations.NetworkModel
+import com.cramsan.framework.annotations.api.ResponseBody
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Response model for a common area.
+ */
+@NetworkModel
+@Serializable
+data class CommonAreaNetworkResponse(
+    @SerialName("common_area_id")
+    val commonAreaId: CommonAreaId,
+    @SerialName("property_id")
+    val propertyId: PropertyId,
+    @SerialName("org_id")
+    val orgId: OrganizationId,
+    @SerialName("name")
+    val name: String,
+    @SerialName("type")
+    val type: String,
+    @SerialName("description")
+    val description: String? = null,
+) : ResponseBody

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/CreateCommonAreaNetworkRequest.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/CreateCommonAreaNetworkRequest.kt
@@ -1,0 +1,26 @@
+package com.cramsan.edifikana.lib.model.network
+
+import com.cramsan.edifikana.lib.model.OrganizationId
+import com.cramsan.edifikana.lib.model.PropertyId
+import com.cramsan.framework.annotations.NetworkModel
+import com.cramsan.framework.annotations.api.RequestBody
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Request to create a new common area.
+ */
+@NetworkModel
+@Serializable
+data class CreateCommonAreaNetworkRequest(
+    @SerialName("property_id")
+    val propertyId: PropertyId,
+    @SerialName("org_id")
+    val orgId: OrganizationId,
+    @SerialName("name")
+    val name: String,
+    @SerialName("type")
+    val type: String,
+    @SerialName("description")
+    val description: String? = null,
+) : RequestBody

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/CreateUnitNetworkRequest.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/CreateUnitNetworkRequest.kt
@@ -1,0 +1,32 @@
+package com.cramsan.edifikana.lib.model.network
+
+import com.cramsan.edifikana.lib.model.OrganizationId
+import com.cramsan.edifikana.lib.model.PropertyId
+import com.cramsan.framework.annotations.NetworkModel
+import com.cramsan.framework.annotations.api.RequestBody
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Request to create a new unit.
+ */
+@NetworkModel
+@Serializable
+data class CreateUnitNetworkRequest(
+    @SerialName("property_id")
+    val propertyId: PropertyId,
+    @SerialName("org_id")
+    val orgId: OrganizationId,
+    @SerialName("unit_number")
+    val unitNumber: String,
+    @SerialName("bedrooms")
+    val bedrooms: Int? = null,
+    @SerialName("bathrooms")
+    val bathrooms: Int? = null,
+    @SerialName("sq_ft")
+    val sqFt: Int? = null,
+    @SerialName("floor")
+    val floor: Int? = null,
+    @SerialName("notes")
+    val notes: String? = null,
+) : RequestBody

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/UnitListNetworkResponse.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/UnitListNetworkResponse.kt
@@ -1,0 +1,16 @@
+package com.cramsan.edifikana.lib.model.network
+
+import com.cramsan.framework.annotations.NetworkModel
+import com.cramsan.framework.annotations.api.ResponseBody
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Response model for a list of units.
+ */
+@NetworkModel
+@Serializable
+data class UnitListNetworkResponse(
+    @SerialName("units")
+    val units: List<UnitNetworkResponse>,
+) : ResponseBody

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/UnitNetworkResponse.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/UnitNetworkResponse.kt
@@ -1,0 +1,35 @@
+package com.cramsan.edifikana.lib.model.network
+
+import com.cramsan.edifikana.lib.model.OrganizationId
+import com.cramsan.edifikana.lib.model.PropertyId
+import com.cramsan.edifikana.lib.model.UnitId
+import com.cramsan.framework.annotations.NetworkModel
+import com.cramsan.framework.annotations.api.ResponseBody
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Response model for a unit.
+ */
+@NetworkModel
+@Serializable
+data class UnitNetworkResponse(
+    @SerialName("unit_id")
+    val unitId: UnitId,
+    @SerialName("property_id")
+    val propertyId: PropertyId,
+    @SerialName("org_id")
+    val orgId: OrganizationId,
+    @SerialName("unit_number")
+    val unitNumber: String,
+    @SerialName("bedrooms")
+    val bedrooms: Int? = null,
+    @SerialName("bathrooms")
+    val bathrooms: Int? = null,
+    @SerialName("sq_ft")
+    val sqFt: Int? = null,
+    @SerialName("floor")
+    val floor: Int? = null,
+    @SerialName("notes")
+    val notes: String? = null,
+) : ResponseBody

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/UpdateCommonAreaNetworkRequest.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/UpdateCommonAreaNetworkRequest.kt
@@ -1,0 +1,20 @@
+package com.cramsan.edifikana.lib.model.network
+
+import com.cramsan.framework.annotations.NetworkModel
+import com.cramsan.framework.annotations.api.RequestBody
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Request to update an existing common area.
+ */
+@NetworkModel
+@Serializable
+data class UpdateCommonAreaNetworkRequest(
+    @SerialName("name")
+    val name: String? = null,
+    @SerialName("type")
+    val type: String? = null,
+    @SerialName("description")
+    val description: String? = null,
+) : RequestBody

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/UpdateUnitNetworkRequest.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/UpdateUnitNetworkRequest.kt
@@ -1,0 +1,26 @@
+package com.cramsan.edifikana.lib.model.network
+
+import com.cramsan.framework.annotations.NetworkModel
+import com.cramsan.framework.annotations.api.RequestBody
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Request to update an existing unit.
+ */
+@NetworkModel
+@Serializable
+data class UpdateUnitNetworkRequest(
+    @SerialName("unit_number")
+    val unitNumber: String? = null,
+    @SerialName("bedrooms")
+    val bedrooms: Int? = null,
+    @SerialName("bathrooms")
+    val bathrooms: Int? = null,
+    @SerialName("sq_ft")
+    val sqFt: Int? = null,
+    @SerialName("floor")
+    val floor: Int? = null,
+    @SerialName("notes")
+    val notes: String? = null,
+) : RequestBody


### PR DESCRIPTION
## Summary

- Adds `UnitId` and `CommonAreaId` inline value classes implementing `PathParam` for type-safe ID handling
- Adds `CommonAreaType` enum (`LOBBY`, `POOL`, `GYM`, `PARKING`, `LAUNDRY`, `ROOFTOP`, `OTHER`) with `@SerialName` annotations and `fromString()` companion
- Adds network request/response models for units: `UnitNetworkResponse`, `UnitListNetworkResponse`, `CreateUnitNetworkRequest`, `UpdateUnitNetworkRequest`
- Adds network request/response models for common areas: `CommonAreaNetworkResponse`, `CommonAreaListNetworkResponse`, `CreateCommonAreaNetworkRequest`, `UpdateCommonAreaNetworkRequest`

Part of #386

## Test plan

- [x] `./gradlew :edifikana:shared:release` passes with no errors
- [x] Detekt passes on all new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)