### PR TITLE
[EDIFIKANA] #419 Implementing  Occupant API/Controller/Service/Datastore/models

### DIFF
--- a/edifikana/api/src/commonMain/kotlin/com/cramsan/edifikana/api/OccupantApi.kt
+++ b/edifikana/api/src/commonMain/kotlin/com/cramsan/edifikana/api/OccupantApi.kt
@@ -1,0 +1,59 @@
+package com.cramsan.edifikana.api
+
+import com.cramsan.edifikana.lib.model.network.occupant.CreateOccupantNetworkRequest
+import com.cramsan.edifikana.lib.model.network.occupant.GetOccupantsForUnitQueryParams
+import com.cramsan.edifikana.lib.model.network.occupant.OccupantListNetworkResponse
+import com.cramsan.edifikana.lib.model.network.occupant.OccupantNetworkResponse
+import com.cramsan.edifikana.lib.model.network.occupant.UpdateOccupantNetworkRequest
+import com.cramsan.edifikana.lib.model.occupant.OccupantId
+import com.cramsan.framework.annotations.NetworkModel
+import com.cramsan.framework.annotations.api.NoPathParam
+import com.cramsan.framework.annotations.api.NoQueryParam
+import com.cramsan.framework.annotations.api.NoRequestBody
+import com.cramsan.framework.networkapi.Api
+import io.ktor.http.HttpMethod
+
+/**
+ * API definition for occupant operations.
+ *
+ * Occupants are people associated with a unit — tenants or residents.
+ * Write operations require ADMIN role or higher. Read operations require EMPLOYEE role or higher.
+ */
+@OptIn(NetworkModel::class)
+object OccupantApi : Api("occupants") {
+
+    val createOccupant = operation<
+        CreateOccupantNetworkRequest,
+        NoQueryParam,
+        NoPathParam,
+        OccupantNetworkResponse
+        >(HttpMethod.Post)
+
+    val getOccupant = operation<
+        NoRequestBody,
+        NoQueryParam,
+        OccupantId,
+        OccupantNetworkResponse
+        >(HttpMethod.Get)
+
+    val listOccupantsForUnit = operation<
+        NoRequestBody,
+        GetOccupantsForUnitQueryParams,
+        NoPathParam,
+        OccupantListNetworkResponse
+        >(HttpMethod.Get)
+
+    val updateOccupant = operation<
+        UpdateOccupantNetworkRequest,
+        NoQueryParam,
+        OccupantId,
+        OccupantNetworkResponse
+        >(HttpMethod.Put)
+
+    val removeOccupant = operation<
+        NoRequestBody,
+        NoQueryParam,
+        OccupantId,
+        OccupantNetworkResponse
+        >(HttpMethod.Delete)
+}

--- a/edifikana/back-end/src/integTest/kotlin/com/cramsan/edifikana/server/datastore/supabase/SupabaseIntegrationTest.kt
+++ b/edifikana/back-end/src/integTest/kotlin/com/cramsan/edifikana/server/datastore/supabase/SupabaseIntegrationTest.kt
@@ -11,6 +11,9 @@ import com.cramsan.edifikana.lib.model.invite.InviteId
 import com.cramsan.edifikana.lib.model.invite.InviteRole
 import com.cramsan.edifikana.lib.model.notification.NotificationId
 import com.cramsan.edifikana.lib.model.organization.OrganizationId
+import com.cramsan.edifikana.lib.model.occupant.OccupancyStatus
+import com.cramsan.edifikana.lib.model.occupant.OccupantId
+import com.cramsan.edifikana.lib.model.occupant.OccupantType
 import com.cramsan.edifikana.lib.model.payment.PaymentRecordId
 import com.cramsan.edifikana.lib.model.property.PropertyId
 import com.cramsan.edifikana.lib.model.rent.RentConfigId
@@ -27,6 +30,7 @@ import com.cramsan.edifikana.server.service.models.EventLogEntry
 import com.cramsan.edifikana.server.service.models.Invite
 import com.cramsan.edifikana.server.service.models.Notification
 import com.cramsan.edifikana.server.service.models.Organization
+import com.cramsan.edifikana.server.service.models.Occupant
 import com.cramsan.edifikana.server.service.models.PaymentRecord
 import com.cramsan.edifikana.server.service.models.Property
 import com.cramsan.edifikana.server.service.models.RentConfig
@@ -67,6 +71,7 @@ abstract class SupabaseIntegrationTest : CoroutineTest(), KoinTest {
     protected val unitDatastore: SupabaseUnitDatastore by inject()
     protected val paymentRecordDatastore: SupabasePaymentRecordDatastore by inject()
     protected val rentConfigDatastore: SupabaseRentConfigDatastore by inject()
+    protected val occupantDatastore: SupabaseOccupantDatastore by inject()
 
     private val eventLogResources = mutableSetOf<EventLogEntryId>()
     private val commonAreaResources = mutableSetOf<CommonAreaId>()
@@ -82,6 +87,7 @@ abstract class SupabaseIntegrationTest : CoroutineTest(), KoinTest {
     private val unitResources = mutableSetOf<UnitId>()
     private val paymentRecordResources = mutableSetOf<PaymentRecordId>()
     private val rentConfigResources = mutableSetOf<RentConfigId>()
+    private val occupantResources = mutableSetOf<OccupantId>()
 
     @BeforeEach
     fun supabaseSetup() {
@@ -146,6 +152,10 @@ abstract class SupabaseIntegrationTest : CoroutineTest(), KoinTest {
 
     private fun registerRentConfigForDeletion(rentConfigId: RentConfigId) {
         rentConfigResources.add(rentConfigId)
+    }
+
+    private fun registerOccupantForDeletion(occupantId: OccupantId) {
+        occupantResources.add(occupantId)
     }
 
     protected fun createTestUser(email: String): UserId {
@@ -306,6 +316,12 @@ abstract class SupabaseIntegrationTest : CoroutineTest(), KoinTest {
         }
     }
 
+    fun Result<Occupant>.registerOccupantForDeletion(): Result<Occupant> {
+        return this.onSuccess { occupant ->
+            registerOccupantForDeletion(occupant.id)
+        }
+    }
+
     fun registerSupabaseUserForDeletion(userId: String) {
         supabaseUsers.add(userId)
     }
@@ -326,6 +342,35 @@ abstract class SupabaseIntegrationTest : CoroutineTest(), KoinTest {
         }
         registerEmployeeForDeletion(empId)
         return empId
+    }
+
+    protected fun createTestOccupant(
+        unitId: UnitId,
+        orgId: OrganizationId,
+        userId: UserId? = null,
+        addedBy: UserId? = null,
+        name: String = "Test Occupant",
+        email: String? = null,
+        occupantType: OccupantType = OccupantType.TENANT,
+        isPrimary: Boolean = false,
+        startDate: kotlinx.datetime.LocalDate = kotlinx.datetime.LocalDate(2026, 1, 1),
+    ): OccupantId {
+        val occupantId = runBlocking {
+            occupantDatastore.createOccupant(
+                unitId = unitId,
+                orgId = orgId,
+                userId = userId,
+                addedBy = addedBy,
+                name = name,
+                email = email,
+                occupantType = occupantType,
+                isPrimary = isPrimary,
+                startDate = startDate,
+                endDate = null,
+            ).getOrThrow().id
+        }
+        registerOccupantForDeletion(occupantId)
+        return occupantId
     }
 
     @AfterTest
@@ -375,6 +420,9 @@ abstract class SupabaseIntegrationTest : CoroutineTest(), KoinTest {
                 rentConfigResources.forEach {
                     results += rentConfigDatastore.purgeRentConfig(it)
                 }
+                occupantResources.forEach {
+                    results += occupantDatastore.purgeOccupant(it)
+                }
                 unitResources.forEach {
                     results += unitDatastore.deleteUnit(it)
                     results += unitDatastore.purgeUnit(it)
@@ -404,6 +452,7 @@ abstract class SupabaseIntegrationTest : CoroutineTest(), KoinTest {
             unitResources.clear()
             paymentRecordResources.clear()
             rentConfigResources.clear()
+            occupantResources.clear()
             commonAreaResources.clear()
             taskResources.clear()
             propertyResources.clear()

--- a/edifikana/back-end/src/integTest/kotlin/com/cramsan/edifikana/server/datastore/supabase/SupabaseIntegrationTest.kt
+++ b/edifikana/back-end/src/integTest/kotlin/com/cramsan/edifikana/server/datastore/supabase/SupabaseIntegrationTest.kt
@@ -346,7 +346,6 @@ abstract class SupabaseIntegrationTest : CoroutineTest(), KoinTest {
 
     protected fun createTestOccupant(
         unitId: UnitId,
-        orgId: OrganizationId,
         userId: UserId? = null,
         addedBy: UserId? = null,
         name: String = "Test Occupant",
@@ -358,7 +357,6 @@ abstract class SupabaseIntegrationTest : CoroutineTest(), KoinTest {
         val occupantId = runBlocking {
             occupantDatastore.createOccupant(
                 unitId = unitId,
-                orgId = orgId,
                 userId = userId,
                 addedBy = addedBy,
                 name = name,

--- a/edifikana/back-end/src/integTest/kotlin/com/cramsan/edifikana/server/datastore/supabase/SupabaseOccupantDatastoreIntegrationTest.kt
+++ b/edifikana/back-end/src/integTest/kotlin/com/cramsan/edifikana/server/datastore/supabase/SupabaseOccupantDatastoreIntegrationTest.kt
@@ -1,0 +1,217 @@
+package com.cramsan.edifikana.server.datastore.supabase
+
+import com.cramsan.edifikana.lib.model.occupant.OccupancyStatus
+import com.cramsan.edifikana.lib.model.occupant.OccupantType
+import com.cramsan.edifikana.lib.model.organization.OrganizationId
+import com.cramsan.edifikana.lib.model.property.PropertyId
+import com.cramsan.edifikana.lib.model.unit.UnitId
+import com.cramsan.edifikana.lib.model.user.UserId
+import com.cramsan.framework.utils.uuid.UUID
+import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.LocalDate
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SupabaseOccupantDatastoreIntegrationTest : SupabaseIntegrationTest() {
+
+    private lateinit var testPrefix: String
+    private var propertyId: PropertyId? = null
+    private var testUserId: UserId? = null
+    private var orgId: OrganizationId? = null
+    private var unitId: UnitId? = null
+
+    @BeforeTest
+    fun setup() {
+        testPrefix = UUID.random()
+        runBlocking {
+            testUserId = createTestUser("occ-user-${testPrefix}@test.com")
+            orgId = createTestOrganization("occ_org_$testPrefix", "")
+            propertyId = createTestProperty("${testPrefix}_OccProp", testUserId!!, orgId!!)
+            unitId = createTestUnit(propertyId!!, "${testPrefix}_U1")
+        }
+    }
+
+    @Test
+    fun `createOccupant should return the created record`() = runCoroutineTest {
+        val startDate = LocalDate(2026, 1, 1)
+
+        val result = occupantDatastore.createOccupant(
+            unitId = unitId!!,
+            orgId = orgId!!,
+            userId = testUserId,
+            addedBy = testUserId,
+            name = "Jane Doe",
+            email = "jane@example.com",
+            occupantType = OccupantType.TENANT,
+            isPrimary = true,
+            startDate = startDate,
+            endDate = null,
+        ).registerOccupantForDeletion()
+
+        assertTrue(result.isSuccess)
+        val occupant = result.getOrNull()
+        assertNotNull(occupant)
+        assertEquals(unitId, occupant.unitId)
+        assertEquals(testUserId, occupant.userId)
+        assertEquals(OccupantType.TENANT, occupant.occupantType)
+        assertTrue(occupant.isPrimary)
+        assertEquals(startDate, occupant.startDate)
+        assertNull(occupant.endDate)
+        assertEquals(OccupancyStatus.ACTIVE, occupant.status)
+    }
+
+    @Test
+    fun `getOccupant should return the created record`() = runCoroutineTest {
+        val createResult = occupantDatastore.createOccupant(
+            unitId = unitId!!,
+            orgId = orgId!!,
+            userId = testUserId,
+            addedBy = testUserId,
+            name = "John Smith",
+            email = null,
+            occupantType = OccupantType.TENANT,
+            isPrimary = false,
+            startDate = LocalDate(2026, 1, 1),
+            endDate = null,
+        ).registerOccupantForDeletion()
+        assertTrue(createResult.isSuccess)
+        val created = createResult.getOrNull()!!
+
+        val getResult = occupantDatastore.getOccupant(created.id)
+
+        assertTrue(getResult.isSuccess)
+        val fetched = getResult.getOrNull()
+        assertNotNull(fetched)
+        assertEquals(created.id, fetched.id)
+        assertEquals(unitId, fetched.unitId)
+    }
+
+    @Test
+    fun `listOccupantsForUnit should return active occupants only by default`() = runCoroutineTest {
+        val unit2Id = createTestUnit(propertyId!!, "${testPrefix}_U2")
+
+        val active1 = occupantDatastore.createOccupant(
+            unitId = unit2Id,
+            orgId = orgId!!,
+            userId = null,
+            addedBy = testUserId,
+            name = "Alice",
+            email = null,
+            occupantType = OccupantType.TENANT,
+            isPrimary = true,
+            startDate = LocalDate(2026, 1, 1),
+            endDate = null,
+        ).registerOccupantForDeletion().getOrThrow()
+
+        val active2 = occupantDatastore.createOccupant(
+            unitId = unit2Id,
+            orgId = orgId!!,
+            userId = null,
+            addedBy = testUserId,
+            name = "Bob",
+            email = null,
+            occupantType = OccupantType.RESIDENT,
+            isPrimary = false,
+            startDate = LocalDate(2026, 2, 1),
+            endDate = null,
+        ).registerOccupantForDeletion().getOrThrow()
+
+        // Soft-remove one occupant
+        occupantDatastore.softRemoveOccupant(active2.id, LocalDate(2026, 3, 1)).getOrThrow()
+
+        val activeOnly = occupantDatastore.listOccupantsForUnit(unit2Id, includeInactive = false).getOrThrow()
+        val allOccupants = occupantDatastore.listOccupantsForUnit(unit2Id, includeInactive = true).getOrThrow()
+
+        assertEquals(1, activeOnly.size)
+        assertEquals(active1.id, activeOnly.first().id)
+
+        assertEquals(2, allOccupants.size)
+    }
+
+    @Test
+    fun `clearPrimaryForUnit should unset is_primary on all active occupants`() = runCoroutineTest {
+        val unit3Id = createTestUnit(propertyId!!, "${testPrefix}_U3")
+
+        occupantDatastore.createOccupant(
+            unitId = unit3Id,
+            orgId = orgId!!,
+            userId = null,
+            addedBy = testUserId,
+            name = "Carol",
+            email = null,
+            occupantType = OccupantType.TENANT,
+            isPrimary = true,
+            startDate = LocalDate(2026, 1, 1),
+            endDate = null,
+        ).registerOccupantForDeletion().getOrThrow()
+
+        occupantDatastore.clearPrimaryForUnit(unit3Id).getOrThrow()
+
+        val occupants = occupantDatastore.listOccupantsForUnit(unit3Id, includeInactive = false).getOrThrow()
+        assertTrue(occupants.all { !it.isPrimary })
+    }
+
+    @Test
+    fun `softRemoveOccupant should set status to INACTIVE without deleting the row`() = runCoroutineTest {
+        val createResult = occupantDatastore.createOccupant(
+            unitId = unitId!!,
+            orgId = orgId!!,
+            userId = null,
+            addedBy = testUserId,
+            name = "Dave",
+            email = null,
+            occupantType = OccupantType.TENANT,
+            isPrimary = false,
+            startDate = LocalDate(2026, 1, 1),
+            endDate = null,
+        ).registerOccupantForDeletion()
+        val created = createResult.getOrThrow()
+
+        val today = LocalDate(2026, 4, 23)
+        val removeResult = occupantDatastore.softRemoveOccupant(created.id, today)
+
+        assertTrue(removeResult.isSuccess)
+        val removed = removeResult.getOrNull()
+        assertNotNull(removed)
+        assertEquals(OccupancyStatus.INACTIVE, removed.status)
+        assertEquals(today, removed.endDate)
+
+        // Row still exists (soft-deleted, not hard-deleted)
+        val fetched = occupantDatastore.getOccupant(created.id).getOrNull()
+        assertNotNull(fetched)
+        assertEquals(OccupancyStatus.INACTIVE, fetched.status)
+    }
+
+    @Test
+    fun `updateOccupant should apply only provided fields`() = runCoroutineTest {
+        val created = occupantDatastore.createOccupant(
+            unitId = unitId!!,
+            orgId = orgId!!,
+            userId = null,
+            addedBy = testUserId,
+            name = "Eve",
+            email = null,
+            occupantType = OccupantType.TENANT,
+            isPrimary = false,
+            startDate = LocalDate(2026, 1, 1),
+            endDate = null,
+        ).registerOccupantForDeletion().getOrThrow()
+
+        val updated = occupantDatastore.updateOccupant(
+            occupantId = created.id,
+            occupantType = OccupantType.RESIDENT,
+            isPrimary = null,
+            endDate = null,
+            status = null,
+        ).getOrThrow()
+
+        assertEquals(OccupantType.RESIDENT, updated.occupantType)
+        assertFalse(updated.isPrimary)
+        assertEquals(OccupancyStatus.ACTIVE, updated.status)
+    }
+}

--- a/edifikana/back-end/src/integTest/kotlin/com/cramsan/edifikana/server/datastore/supabase/SupabaseOccupantDatastoreIntegrationTest.kt
+++ b/edifikana/back-end/src/integTest/kotlin/com/cramsan/edifikana/server/datastore/supabase/SupabaseOccupantDatastoreIntegrationTest.kt
@@ -42,7 +42,6 @@ class SupabaseOccupantDatastoreIntegrationTest : SupabaseIntegrationTest() {
 
         val result = occupantDatastore.createOccupant(
             unitId = unitId!!,
-            orgId = orgId!!,
             userId = testUserId,
             addedBy = testUserId,
             name = "Jane Doe",
@@ -58,6 +57,8 @@ class SupabaseOccupantDatastoreIntegrationTest : SupabaseIntegrationTest() {
         assertNotNull(occupant)
         assertEquals(unitId, occupant.unitId)
         assertEquals(testUserId, occupant.userId)
+        assertEquals("Jane Doe", occupant.name)
+        assertEquals("jane@example.com", occupant.email)
         assertEquals(OccupantType.TENANT, occupant.occupantType)
         assertTrue(occupant.isPrimary)
         assertEquals(startDate, occupant.startDate)
@@ -69,7 +70,6 @@ class SupabaseOccupantDatastoreIntegrationTest : SupabaseIntegrationTest() {
     fun `getOccupant should return the created record`() = runCoroutineTest {
         val createResult = occupantDatastore.createOccupant(
             unitId = unitId!!,
-            orgId = orgId!!,
             userId = testUserId,
             addedBy = testUserId,
             name = "John Smith",
@@ -97,7 +97,6 @@ class SupabaseOccupantDatastoreIntegrationTest : SupabaseIntegrationTest() {
 
         val active1 = occupantDatastore.createOccupant(
             unitId = unit2Id,
-            orgId = orgId!!,
             userId = null,
             addedBy = testUserId,
             name = "Alice",
@@ -110,7 +109,6 @@ class SupabaseOccupantDatastoreIntegrationTest : SupabaseIntegrationTest() {
 
         val active2 = occupantDatastore.createOccupant(
             unitId = unit2Id,
-            orgId = orgId!!,
             userId = null,
             addedBy = testUserId,
             name = "Bob",
@@ -134,12 +132,98 @@ class SupabaseOccupantDatastoreIntegrationTest : SupabaseIntegrationTest() {
     }
 
     @Test
+    fun `listOccupantsForProperty should aggregate occupants across all units and respect includeInactive`() =
+        runCoroutineTest {
+            val unitA = createTestUnit(propertyId!!, "${testPrefix}_PA")
+            val unitB = createTestUnit(propertyId!!, "${testPrefix}_PB")
+
+            // Occupant in another property to confirm cross-property isolation
+            val otherOrgId = createTestOrganization("occ_org_other_$testPrefix", "")
+            val otherPropertyId = createTestProperty("${testPrefix}_OtherProp", testUserId!!, otherOrgId)
+            val otherUnitId = createTestUnit(otherPropertyId, "${testPrefix}_OU1")
+            val otherOccupant = occupantDatastore.createOccupant(
+                unitId = otherUnitId,
+                userId = null,
+                addedBy = testUserId,
+                name = "Outsider",
+                email = null,
+                occupantType = OccupantType.TENANT,
+                isPrimary = true,
+                startDate = LocalDate(2026, 1, 1),
+                endDate = null,
+            ).registerOccupantForDeletion().getOrThrow()
+
+            val activeA = occupantDatastore.createOccupant(
+                unitId = unitA,
+                userId = null,
+                addedBy = testUserId,
+                name = "Frank",
+                email = null,
+                occupantType = OccupantType.TENANT,
+                isPrimary = true,
+                startDate = LocalDate(2026, 1, 1),
+                endDate = null,
+            ).registerOccupantForDeletion().getOrThrow()
+
+            val activeB = occupantDatastore.createOccupant(
+                unitId = unitB,
+                userId = null,
+                addedBy = testUserId,
+                name = "Grace",
+                email = null,
+                occupantType = OccupantType.RESIDENT,
+                isPrimary = false,
+                startDate = LocalDate(2026, 2, 1),
+                endDate = null,
+            ).registerOccupantForDeletion().getOrThrow()
+
+            val toDeactivate = occupantDatastore.createOccupant(
+                unitId = unitB,
+                userId = null,
+                addedBy = testUserId,
+                name = "Henry",
+                email = null,
+                occupantType = OccupantType.TENANT,
+                isPrimary = false,
+                startDate = LocalDate(2026, 1, 1),
+                endDate = null,
+            ).registerOccupantForDeletion().getOrThrow()
+
+            occupantDatastore.softRemoveOccupant(toDeactivate.id, LocalDate(2026, 3, 1)).getOrThrow()
+
+            val activeOnly = occupantDatastore
+                .listOccupantsForProperty(propertyId!!, includeInactive = false)
+                .getOrThrow()
+            val allOccupants = occupantDatastore
+                .listOccupantsForProperty(propertyId!!, includeInactive = true)
+                .getOrThrow()
+
+            val activeOnlyIds = activeOnly.map { it.id }.toSet()
+            assertEquals(setOf(activeA.id, activeB.id), activeOnlyIds)
+            assertFalse(activeOnlyIds.contains(otherOccupant.id))
+
+            val allIds = allOccupants.map { it.id }.toSet()
+            assertEquals(setOf(activeA.id, activeB.id, toDeactivate.id), allIds)
+            assertFalse(allIds.contains(otherOccupant.id))
+        }
+
+    @Test
+    fun `listOccupantsForProperty should return empty list when property has no units`() = runCoroutineTest {
+        val emptyOrgId = createTestOrganization("occ_org_empty_$testPrefix", "")
+        val emptyPropertyId = createTestProperty("${testPrefix}_EmptyProp", testUserId!!, emptyOrgId)
+
+        val result = occupantDatastore.listOccupantsForProperty(emptyPropertyId, includeInactive = false)
+
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrThrow().isEmpty())
+    }
+
+    @Test
     fun `clearPrimaryForUnit should unset is_primary on all active occupants`() = runCoroutineTest {
         val unit3Id = createTestUnit(propertyId!!, "${testPrefix}_U3")
 
         occupantDatastore.createOccupant(
             unitId = unit3Id,
-            orgId = orgId!!,
             userId = null,
             addedBy = testUserId,
             name = "Carol",
@@ -160,7 +244,6 @@ class SupabaseOccupantDatastoreIntegrationTest : SupabaseIntegrationTest() {
     fun `softRemoveOccupant should set status to INACTIVE without deleting the row`() = runCoroutineTest {
         val createResult = occupantDatastore.createOccupant(
             unitId = unitId!!,
-            orgId = orgId!!,
             userId = null,
             addedBy = testUserId,
             name = "Dave",
@@ -191,7 +274,6 @@ class SupabaseOccupantDatastoreIntegrationTest : SupabaseIntegrationTest() {
     fun `updateOccupant should apply only provided fields`() = runCoroutineTest {
         val created = occupantDatastore.createOccupant(
             unitId = unitId!!,
-            orgId = orgId!!,
             userId = null,
             addedBy = testUserId,
             name = "Eve",
@@ -204,12 +286,16 @@ class SupabaseOccupantDatastoreIntegrationTest : SupabaseIntegrationTest() {
 
         val updated = occupantDatastore.updateOccupant(
             occupantId = created.id,
+            name = "Eve Updated",
+            email = "eve@example.com",
             occupantType = OccupantType.RESIDENT,
             isPrimary = null,
             endDate = null,
             status = null,
         ).getOrThrow()
 
+        assertEquals("Eve Updated", updated.name)
+        assertEquals("eve@example.com", updated.email)
         assertEquals(OccupantType.RESIDENT, updated.occupantType)
         assertFalse(updated.isPrimary)
         assertEquals(OccupancyStatus.ACTIVE, updated.status)

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/controller/NetworkMappers.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/controller/NetworkMappers.kt
@@ -11,6 +11,7 @@ import com.cramsan.edifikana.lib.model.network.employee.EmployeeNetworkResponse
 import com.cramsan.edifikana.lib.model.network.eventLog.EventLogEntryNetworkResponse
 import com.cramsan.edifikana.lib.model.network.invite.InviteNetworkResponse
 import com.cramsan.edifikana.lib.model.network.notification.NotificationNetworkResponse
+import com.cramsan.edifikana.lib.model.network.occupant.OccupantNetworkResponse
 import com.cramsan.edifikana.lib.model.network.organization.MemberNetworkResponse
 import com.cramsan.edifikana.lib.model.network.organization.OrganizationNetworkResponse
 import com.cramsan.edifikana.lib.model.network.property.PropertyNetworkResponse
@@ -28,6 +29,7 @@ import com.cramsan.edifikana.server.service.models.Employee
 import com.cramsan.edifikana.server.service.models.EventLogEntry
 import com.cramsan.edifikana.server.service.models.Invite
 import com.cramsan.edifikana.server.service.models.Notification
+import com.cramsan.edifikana.server.service.models.Occupant
 import com.cramsan.edifikana.server.service.models.OrgMemberView
 import com.cramsan.edifikana.server.service.models.Organization
 import com.cramsan.edifikana.server.service.models.Property
@@ -300,5 +302,24 @@ fun RentConfig.toRentConfigNetworkResponse(): RentConfigNetworkResponse {
         updatedAt = updatedAt,
         updatedBy = updatedBy,
         createdAt = createdAt,
+    )
+}
+
+/**
+ * Converts an [Occupant] domain model to an [OccupantNetworkResponse] network model.
+ */
+@NetworkModel
+fun Occupant.toOccupantNetworkResponse(): OccupantNetworkResponse {
+    return OccupantNetworkResponse(
+        id = id,
+        unitId = unitId,
+        userId = userId,
+        addedBy = addedBy,
+        occupantType = occupantType,
+        isPrimary = isPrimary,
+        startDate = startDate.toString(),
+        endDate = endDate?.toString(),
+        status = status,
+        addedAt = addedAt.epochSeconds,
     )
 }

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/controller/NetworkMappers.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/controller/NetworkMappers.kt
@@ -315,6 +315,8 @@ fun Occupant.toOccupantNetworkResponse(): OccupantNetworkResponse {
         unitId = unitId,
         userId = userId,
         addedBy = addedBy,
+        name = name,
+        email = email,
         occupantType = occupantType,
         isPrimary = isPrimary,
         startDate = startDate,

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/controller/NetworkMappers.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/controller/NetworkMappers.kt
@@ -317,9 +317,9 @@ fun Occupant.toOccupantNetworkResponse(): OccupantNetworkResponse {
         addedBy = addedBy,
         occupantType = occupantType,
         isPrimary = isPrimary,
-        startDate = startDate.toString(),
-        endDate = endDate?.toString(),
+        startDate = startDate,
+        endDate = endDate,
         status = status,
-        addedAt = addedAt.epochSeconds,
+        addedAt = addedAt,
     )
 }

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/controller/OccupantController.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/controller/OccupantController.kt
@@ -1,0 +1,192 @@
+package com.cramsan.edifikana.server.controller
+
+import com.cramsan.edifikana.api.OccupantApi
+import com.cramsan.edifikana.lib.model.network.occupant.CreateOccupantNetworkRequest
+import com.cramsan.edifikana.lib.model.network.occupant.GetOccupantsForUnitQueryParams
+import com.cramsan.edifikana.lib.model.network.occupant.OccupantListNetworkResponse
+import com.cramsan.edifikana.lib.model.network.occupant.OccupantNetworkResponse
+import com.cramsan.edifikana.lib.model.network.occupant.UpdateOccupantNetworkRequest
+import com.cramsan.edifikana.lib.model.occupant.OccupantId
+import com.cramsan.edifikana.server.controller.authentication.SupabaseContextPayload
+import com.cramsan.edifikana.server.service.OccupantService
+import com.cramsan.edifikana.server.service.authorization.RBACService
+import com.cramsan.edifikana.server.service.models.UserRole
+import com.cramsan.framework.annotations.NetworkModel
+import com.cramsan.framework.annotations.api.NoPathParam
+import com.cramsan.framework.annotations.api.NoQueryParam
+import com.cramsan.framework.annotations.api.NoRequestBody
+import com.cramsan.framework.core.ktor.Controller
+import com.cramsan.framework.core.ktor.OperationHandler.register
+import com.cramsan.framework.core.ktor.OperationRequest
+import com.cramsan.framework.core.ktor.auth.ClientContext
+import com.cramsan.framework.core.ktor.auth.ContextRetriever
+import com.cramsan.framework.core.ktor.handler
+import com.cramsan.framework.utils.exceptions.ClientRequestExceptions.NotFoundException
+import com.cramsan.framework.utils.exceptions.ClientRequestExceptions.UnauthorizedException
+import io.ktor.server.routing.Routing
+import kotlinx.datetime.LocalDate
+
+/**
+ * Controller for occupant operations.
+ *
+ * Write operations (create, update, remove) require ADMIN role or higher.
+ * Read operations (get, list) require EMPLOYEE role or higher.
+ *
+ * RBAC for create and list resolves via the unitId in the request body / query params.
+ * RBAC for get, update, and remove resolves via the occupantId (occupant → unit → org lookup).
+ */
+@OptIn(NetworkModel::class)
+class OccupantController(
+    private val occupantService: OccupantService,
+    private val rbacService: RBACService,
+    private val contextRetriever: ContextRetriever<SupabaseContextPayload>,
+) : Controller {
+
+    private val unauthorizedMsg = "You are not authorized to perform this action in your organization."
+
+    /**
+     * Adds a new occupant to a unit. Requires ADMIN role or higher.
+     */
+    suspend fun createOccupant(
+        request: OperationRequest<
+            CreateOccupantNetworkRequest,
+            NoQueryParam,
+            NoPathParam,
+            ClientContext.AuthenticatedClientContext<SupabaseContextPayload>
+            >
+    ): OccupantNetworkResponse {
+        if (!rbacService.hasRoleOrHigher(request.context, request.requestBody.unitId, UserRole.ADMIN)) {
+            throw UnauthorizedException(unauthorizedMsg)
+        }
+        return occupantService.addOccupant(
+            unitId = request.requestBody.unitId,
+            userId = request.requestBody.userId,
+            addedBy = request.context.payload.userId,
+            name = request.requestBody.name,
+            email = request.requestBody.email,
+            occupantType = request.requestBody.occupantType,
+            isPrimary = request.requestBody.isPrimary,
+            startDate = LocalDate.parse(request.requestBody.startDate),
+            endDate = request.requestBody.endDate?.let { LocalDate.parse(it) },
+        ).toOccupantNetworkResponse()
+    }
+
+    /**
+     * Retrieves a single occupant. Requires EMPLOYEE role or higher, OR the caller is the occupant's linked user.
+     * Returns 404 if not found or unauthorized (to avoid leaking existence).
+     */
+    suspend fun getOccupant(
+        request: OperationRequest<
+            NoRequestBody,
+            NoQueryParam,
+            OccupantId,
+            ClientContext.AuthenticatedClientContext<SupabaseContextPayload>
+            >
+    ): OccupantNetworkResponse {
+        val hasStaffAccess = rbacService.hasRoleOrHigher(request.context, request.pathParam, UserRole.EMPLOYEE)
+        if (hasStaffAccess) {
+            return occupantService.getOccupant(request.pathParam)?.toOccupantNetworkResponse()
+                ?: throw NotFoundException("Occupant not found.")
+        }
+        // Residents can read their own occupant record (where userId matches the caller).
+        val occupant = occupantService.getOccupant(request.pathParam)
+            ?: throw NotFoundException("Occupant not found.")
+        if (occupant.userId == request.context.payload.userId) {
+            return occupant.toOccupantNetworkResponse()
+        }
+        throw NotFoundException("Occupant not found.")
+    }
+
+    /**
+     * Lists occupants for a unit. Requires EMPLOYEE role or higher.
+     */
+    suspend fun listOccupantsForUnit(
+        request: OperationRequest<
+            NoRequestBody,
+            GetOccupantsForUnitQueryParams,
+            NoPathParam,
+            ClientContext.AuthenticatedClientContext<SupabaseContextPayload>
+            >
+    ): OccupantListNetworkResponse {
+        if (!rbacService.hasRoleOrHigher(request.context, request.queryParam.unitId, UserRole.EMPLOYEE)) {
+            throw UnauthorizedException(unauthorizedMsg)
+        }
+        val occupants = occupantService.listOccupantsForUnit(
+            unitId = request.queryParam.unitId,
+            includeInactive = request.queryParam.includeInactive,
+        ).map { it.toOccupantNetworkResponse() }
+        return OccupantListNetworkResponse(occupants)
+    }
+
+    /**
+     * Updates an existing occupant. Requires ADMIN role or higher.
+     */
+    suspend fun updateOccupant(
+        request: OperationRequest<
+            UpdateOccupantNetworkRequest,
+            NoQueryParam,
+            OccupantId,
+            ClientContext.AuthenticatedClientContext<SupabaseContextPayload>
+            >
+    ): OccupantNetworkResponse {
+        if (!rbacService.hasRoleOrHigher(request.context, request.pathParam, UserRole.ADMIN)) {
+            throw UnauthorizedException(unauthorizedMsg)
+        }
+        return try {
+            occupantService.updateOccupant(
+                occupantId = request.pathParam,
+                occupantType = request.requestBody.occupantType,
+                isPrimary = request.requestBody.isPrimary,
+                endDate = request.requestBody.endDate?.let { LocalDate.parse(it) },
+                status = request.requestBody.status,
+            ).toOccupantNetworkResponse()
+        } catch (e: NoSuchElementException) {
+            throw NotFoundException("Occupant not found.", e)
+        }
+    }
+
+    /**
+     * Soft-removes an occupant. Requires ADMIN role or higher.
+     * Returns 409 if the occupant is primary and other active occupants exist for the unit.
+     */
+    suspend fun removeOccupant(
+        request: OperationRequest<
+            NoRequestBody,
+            NoQueryParam,
+            OccupantId,
+            ClientContext.AuthenticatedClientContext<SupabaseContextPayload>
+            >
+    ): OccupantNetworkResponse {
+        if (!rbacService.hasRoleOrHigher(request.context, request.pathParam, UserRole.ADMIN)) {
+            throw UnauthorizedException(unauthorizedMsg)
+        }
+        return try {
+            occupantService.removeOccupant(request.pathParam).toOccupantNetworkResponse()
+        } catch (e: NoSuchElementException) {
+            throw NotFoundException("Occupant not found.", e)
+        }
+    }
+
+    /**
+     * Registers all occupant routes.
+     */
+    override fun registerRoutes(route: Routing) {
+        OccupantApi.register(route) {
+            handler(api.createOccupant, contextRetriever) { request ->
+                createOccupant(request)
+            }
+            handler(api.getOccupant, contextRetriever) { request ->
+                getOccupant(request)
+            }
+            handler(api.listOccupantsForUnit, contextRetriever) { request ->
+                listOccupantsForUnit(request)
+            }
+            handler(api.updateOccupant, contextRetriever) { request ->
+                updateOccupant(request)
+            }
+            handler(api.removeOccupant, contextRetriever) { request ->
+                removeOccupant(request)
+            }
+        }
+    }
+}

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/controller/OccupantController.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/controller/OccupantController.kt
@@ -134,6 +134,8 @@ class OccupantController(
         return try {
             occupantService.updateOccupant(
                 occupantId = request.pathParam,
+                name = request.requestBody.name,
+                email = request.requestBody.email,
                 occupantType = request.requestBody.occupantType,
                 isPrimary = request.requestBody.isPrimary,
                 endDate = request.requestBody.endDate,

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/controller/OccupantController.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/controller/OccupantController.kt
@@ -24,7 +24,6 @@ import com.cramsan.framework.core.ktor.handler
 import com.cramsan.framework.utils.exceptions.ClientRequestExceptions.NotFoundException
 import com.cramsan.framework.utils.exceptions.ClientRequestExceptions.UnauthorizedException
 import io.ktor.server.routing.Routing
-import kotlinx.datetime.LocalDate
 
 /**
  * Controller for occupant operations.
@@ -66,8 +65,8 @@ class OccupantController(
             email = request.requestBody.email,
             occupantType = request.requestBody.occupantType,
             isPrimary = request.requestBody.isPrimary,
-            startDate = LocalDate.parse(request.requestBody.startDate),
-            endDate = request.requestBody.endDate?.let { LocalDate.parse(it) },
+            startDate = request.requestBody.startDate,
+            endDate = request.requestBody.endDate,
         ).toOccupantNetworkResponse()
     }
 
@@ -137,7 +136,7 @@ class OccupantController(
                 occupantId = request.pathParam,
                 occupantType = request.requestBody.occupantType,
                 isPrimary = request.requestBody.isPrimary,
-                endDate = request.requestBody.endDate?.let { LocalDate.parse(it) },
+                endDate = request.requestBody.endDate,
                 status = request.requestBody.status,
             ).toOccupantNetworkResponse()
         } catch (e: NoSuchElementException) {

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/OccupantDatastore.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/OccupantDatastore.kt
@@ -1,0 +1,76 @@
+package com.cramsan.edifikana.server.datastore
+
+import com.cramsan.edifikana.lib.model.occupant.OccupancyStatus
+import com.cramsan.edifikana.lib.model.occupant.OccupantId
+import com.cramsan.edifikana.lib.model.occupant.OccupantType
+import com.cramsan.edifikana.lib.model.organization.OrganizationId
+import com.cramsan.edifikana.lib.model.unit.UnitId
+import com.cramsan.edifikana.lib.model.user.UserId
+import com.cramsan.edifikana.server.service.models.Occupant
+import kotlinx.datetime.LocalDate
+
+/**
+ * Interface for the occupant datastore.
+ */
+interface OccupantDatastore {
+
+    /**
+     * Creates a new occupant record. Returns the [Result] with the created [Occupant].
+     */
+    suspend fun createOccupant(
+        unitId: UnitId,
+        orgId: OrganizationId,
+        userId: UserId?,
+        addedBy: UserId?,
+        name: String,
+        email: String?,
+        occupantType: OccupantType,
+        isPrimary: Boolean,
+        startDate: LocalDate,
+        endDate: LocalDate?,
+    ): Result<Occupant>
+
+    /**
+     * Retrieves an occupant by [occupantId]. Returns null if not found or soft-deleted.
+     */
+    suspend fun getOccupant(occupantId: OccupantId): Result<Occupant?>
+
+    /**
+     * Lists occupants for [unitId]. Returns active occupants only unless [includeInactive] is true.
+     */
+    suspend fun listOccupantsForUnit(
+        unitId: UnitId,
+        includeInactive: Boolean,
+    ): Result<List<Occupant>>
+
+    /**
+     * Sets isPrimary to false on all active occupants for [unitId].
+     * Called before inserting or updating an occupant with [isPrimary]=true.
+     */
+    suspend fun clearPrimaryForUnit(unitId: UnitId): Result<kotlin.Unit>
+
+    /**
+     * Updates an existing occupant. Only non-null fields are applied. Returns the updated [Occupant].
+     */
+    suspend fun updateOccupant(
+        occupantId: OccupantId,
+        occupantType: OccupantType?,
+        isPrimary: Boolean?,
+        endDate: LocalDate?,
+        status: OccupancyStatus?,
+    ): Result<Occupant>
+
+    /**
+     * Soft-removes an occupant by setting [status]=INACTIVE and [endDate] to [today].
+     * The row is not deleted. Returns the updated [Occupant].
+     */
+    suspend fun softRemoveOccupant(
+        occupantId: OccupantId,
+        today: LocalDate,
+    ): Result<Occupant>
+
+    /**
+     * Hard-deletes an occupant row. For integration test cleanup only.
+     */
+    suspend fun purgeOccupant(occupantId: OccupantId): Result<Boolean>
+}

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/OccupantDatastore.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/OccupantDatastore.kt
@@ -4,6 +4,7 @@ import com.cramsan.edifikana.lib.model.occupant.OccupancyStatus
 import com.cramsan.edifikana.lib.model.occupant.OccupantId
 import com.cramsan.edifikana.lib.model.occupant.OccupantType
 import com.cramsan.edifikana.lib.model.organization.OrganizationId
+import com.cramsan.edifikana.lib.model.property.PropertyId
 import com.cramsan.edifikana.lib.model.unit.UnitId
 import com.cramsan.edifikana.lib.model.user.UserId
 import com.cramsan.edifikana.server.service.models.Occupant
@@ -19,7 +20,6 @@ interface OccupantDatastore {
      */
     suspend fun createOccupant(
         unitId: UnitId,
-        orgId: OrganizationId,
         userId: UserId?,
         addedBy: UserId?,
         name: String,
@@ -44,6 +44,15 @@ interface OccupantDatastore {
     ): Result<List<Occupant>>
 
     /**
+     * Lists occupants for [propertyId]. Returns active occupants only unless [includeInactive] is true.
+     */
+    suspend fun listOccupantsForProperty(
+        propertyId: PropertyId,
+        includeInactive: Boolean,
+    ): Result<List<Occupant>>
+
+
+    /**
      * Sets isPrimary to false on all active occupants for [unitId].
      * Called before inserting or updating an occupant with [isPrimary]=true.
      */
@@ -54,6 +63,8 @@ interface OccupantDatastore {
      */
     suspend fun updateOccupant(
         occupantId: OccupantId,
+        name: String?,
+        email: String?,
         occupantType: OccupantType?,
         isPrimary: Boolean?,
         endDate: LocalDate?,

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/OccupantDatastore.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/OccupantDatastore.kt
@@ -3,7 +3,6 @@ package com.cramsan.edifikana.server.datastore
 import com.cramsan.edifikana.lib.model.occupant.OccupancyStatus
 import com.cramsan.edifikana.lib.model.occupant.OccupantId
 import com.cramsan.edifikana.lib.model.occupant.OccupantType
-import com.cramsan.edifikana.lib.model.organization.OrganizationId
 import com.cramsan.edifikana.lib.model.property.PropertyId
 import com.cramsan.edifikana.lib.model.unit.UnitId
 import com.cramsan.edifikana.lib.model.user.UserId

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/UnitDatastore.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/UnitDatastore.kt
@@ -1,6 +1,5 @@
 package com.cramsan.edifikana.server.datastore
 
-import com.cramsan.edifikana.lib.model.organization.OrganizationId
 import com.cramsan.edifikana.lib.model.property.PropertyId
 import com.cramsan.edifikana.lib.model.unit.UnitId
 import com.cramsan.edifikana.server.service.models.Unit

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/supabase/SupabaseMappers.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/supabase/SupabaseMappers.kt
@@ -43,6 +43,7 @@ import com.cramsan.edifikana.server.datastore.supabase.models.PropertyEntity
 import com.cramsan.edifikana.server.datastore.supabase.models.TimeCardEventEntity
 import com.cramsan.edifikana.server.datastore.supabase.models.UnitEntity
 import com.cramsan.edifikana.server.datastore.supabase.models.UserEntity
+import com.cramsan.edifikana.server.datastore.supabase.models.OccupantEntity
 import com.cramsan.edifikana.server.service.models.CommonArea
 import com.cramsan.edifikana.server.service.models.Document
 import com.cramsan.edifikana.server.service.models.PaymentRecord
@@ -569,5 +570,24 @@ fun RentConfigEntity.toRentConfig(): RentConfig {
         updatedAt = this.updatedAt,
         updatedBy = this.updatedBy,
         createdAt = this.createdAt,
+    )
+}
+
+/**
+ * Maps an [OccupantEntity] to the [Occupant] service model.
+ */
+@OptIn(SupabaseModel::class)
+fun OccupantEntity.toOccupant(): com.cramsan.edifikana.server.service.models.Occupant {
+    return com.cramsan.edifikana.server.service.models.Occupant(
+        id = this.occupantId,
+        unitId = this.unitId,
+        userId = this.userId,
+        addedBy = this.addedBy,
+        occupantType = enumValueOf(this.occupantType),
+        isPrimary = this.isPrimary,
+        startDate = this.startDate,
+        endDate = this.endDate,
+        status = enumValueOf(this.status),
+        addedAt = this.addedAt,
     )
 }

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/supabase/SupabaseMappers.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/supabase/SupabaseMappers.kt
@@ -583,6 +583,8 @@ fun OccupantEntity.toOccupant(): com.cramsan.edifikana.server.service.models.Occ
         unitId = this.unitId,
         userId = this.userId,
         addedBy = this.addedBy,
+        name = this.name,
+        email = this.email,
         occupantType = enumValueOf(this.occupantType),
         isPrimary = this.isPrimary,
         startDate = this.startDate,

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/supabase/SupabaseOccupantDatastore.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/supabase/SupabaseOccupantDatastore.kt
@@ -1,0 +1,179 @@
+package com.cramsan.edifikana.server.datastore.supabase
+
+import com.cramsan.edifikana.lib.model.occupant.OccupancyStatus
+import com.cramsan.edifikana.lib.model.occupant.OccupantId
+import com.cramsan.edifikana.lib.model.occupant.OccupantType
+import com.cramsan.edifikana.lib.model.organization.OrganizationId
+import com.cramsan.edifikana.lib.model.unit.UnitId
+import com.cramsan.edifikana.lib.model.user.UserId
+import com.cramsan.edifikana.server.datastore.OccupantDatastore
+import com.cramsan.edifikana.server.datastore.supabase.models.OccupantEntity
+import com.cramsan.edifikana.server.datastore.supabase.models.OccupantEntity.CreateOccupantEntity
+import com.cramsan.edifikana.server.service.models.Occupant
+import com.cramsan.framework.annotations.SupabaseModel
+import com.cramsan.framework.core.runSuspendCatching
+import com.cramsan.framework.logging.logD
+import io.github.jan.supabase.postgrest.Postgrest
+import kotlinx.datetime.LocalDate
+import kotlin.time.ExperimentalTime
+
+/**
+ * Supabase implementation of [OccupantDatastore].
+ */
+@OptIn(ExperimentalTime::class)
+class SupabaseOccupantDatastore(
+    private val postgrest: Postgrest,
+) : OccupantDatastore {
+
+    /**
+     * Inserts a new occupant row and returns the created [Occupant].
+     */
+    @OptIn(SupabaseModel::class)
+    override suspend fun createOccupant(
+        unitId: UnitId,
+        orgId: OrganizationId,
+        userId: UserId?,
+        addedBy: UserId?,
+        name: String,
+        email: String?,
+        occupantType: OccupantType,
+        isPrimary: Boolean,
+        startDate: LocalDate,
+        endDate: LocalDate?,
+    ): Result<Occupant> = runSuspendCatching(TAG) {
+        logD(TAG, "Creating occupant for unit: %s", unitId)
+        val entity = CreateOccupantEntity(
+            unitId = unitId,
+            userId = userId,
+            addedBy = addedBy,
+            occupantType = occupantType.name,
+            isPrimary = isPrimary,
+            startDate = startDate,
+            endDate = endDate,
+        )
+        postgrest.from(OccupantEntity.COLLECTION).insert(entity) {
+            select()
+        }.decodeSingle<OccupantEntity>().toOccupant()
+    }
+
+    /**
+     * Retrieves a single occupant by [occupantId]. Returns null if not found or soft-deleted.
+     */
+    @OptIn(SupabaseModel::class)
+    override suspend fun getOccupant(occupantId: OccupantId): Result<Occupant?> =
+        runSuspendCatching(TAG) {
+            logD(TAG, "Getting occupant: %s", occupantId)
+            postgrest.from(OccupantEntity.COLLECTION).select {
+                filter {
+                    OccupantEntity::occupantId eq occupantId.occupantId
+                    OccupantEntity::deletedAt isExact null
+                }
+            }.decodeSingleOrNull<OccupantEntity>()?.toOccupant()
+        }
+
+    /**
+     * Lists occupants for [unitId]. Filters to ACTIVE status unless [includeInactive] is true.
+     */
+    @OptIn(SupabaseModel::class)
+    override suspend fun listOccupantsForUnit(
+        unitId: UnitId,
+        includeInactive: Boolean,
+    ): Result<List<Occupant>> = runSuspendCatching(TAG) {
+        logD(TAG, "Listing occupants for unit: %s, includeInactive: %s", unitId, includeInactive)
+        postgrest.from(OccupantEntity.COLLECTION).select {
+            filter {
+                OccupantEntity::unitId eq unitId.unitId
+                OccupantEntity::deletedAt isExact null
+                if (!includeInactive) {
+                    OccupantEntity::status eq OccupancyStatus.ACTIVE.name
+                }
+            }
+        }.decodeList<OccupantEntity>().map { it.toOccupant() }
+    }
+
+    /**
+     * Sets [is_primary]=false on all active, non-deleted occupants for [unitId].
+     */
+    @OptIn(SupabaseModel::class)
+    override suspend fun clearPrimaryForUnit(unitId: UnitId): Result<kotlin.Unit> =
+        runSuspendCatching(TAG) {
+            logD(TAG, "Clearing primary for unit: %s", unitId)
+            postgrest.from(OccupantEntity.COLLECTION).update({
+                OccupantEntity::isPrimary setTo false
+            }) {
+                filter {
+                    OccupantEntity::unitId eq unitId.unitId
+                    OccupantEntity::status eq OccupancyStatus.ACTIVE.name
+                    OccupantEntity::deletedAt isExact null
+                }
+            }
+            kotlin.Unit
+        }
+
+    /**
+     * Updates an existing occupant. Only non-null parameters are applied. Returns the updated [Occupant].
+     */
+    @OptIn(SupabaseModel::class)
+    override suspend fun updateOccupant(
+        occupantId: OccupantId,
+        occupantType: OccupantType?,
+        isPrimary: Boolean?,
+        endDate: LocalDate?,
+        status: OccupancyStatus?,
+    ): Result<Occupant> = runSuspendCatching(TAG) {
+        logD(TAG, "Updating occupant: %s", occupantId)
+        postgrest.from(OccupantEntity.COLLECTION).update({
+            occupantType?.let { value -> OccupantEntity::occupantType setTo value.name }
+            isPrimary?.let { value -> OccupantEntity::isPrimary setTo value }
+            endDate?.let { value -> OccupantEntity::endDate setTo value }
+            status?.let { value -> OccupantEntity::status setTo value.name }
+        }) {
+            select()
+            filter {
+                OccupantEntity::occupantId eq occupantId.occupantId
+                OccupantEntity::deletedAt isExact null
+            }
+        }.decodeSingle<OccupantEntity>().toOccupant()
+    }
+
+    /**
+     * Soft-removes an occupant: sets [status]=INACTIVE and [end_date]=[today].
+     * Does not hard-delete the row. Returns the updated [Occupant].
+     */
+    @OptIn(SupabaseModel::class)
+    override suspend fun softRemoveOccupant(
+        occupantId: OccupantId,
+        today: LocalDate,
+    ): Result<Occupant> = runSuspendCatching(TAG) {
+        logD(TAG, "Soft removing occupant: %s", occupantId)
+        postgrest.from(OccupantEntity.COLLECTION).update({
+            OccupantEntity::status setTo OccupancyStatus.INACTIVE.name
+            OccupantEntity::endDate setTo today
+        }) {
+            select()
+            filter {
+                OccupantEntity::occupantId eq occupantId.occupantId
+                OccupantEntity::deletedAt isExact null
+            }
+        }.decodeSingle<OccupantEntity>().toOccupant()
+    }
+
+    /**
+     * Hard-deletes an occupant row. For integration test cleanup only.
+     */
+    @OptIn(SupabaseModel::class)
+    override suspend fun purgeOccupant(occupantId: OccupantId): Result<Boolean> =
+        runSuspendCatching(TAG) {
+            logD(TAG, "Purging occupant: %s", occupantId)
+            postgrest.from(OccupantEntity.COLLECTION).delete {
+                select()
+                filter {
+                    OccupantEntity::occupantId eq occupantId.occupantId
+                }
+            }.decodeSingleOrNull<OccupantEntity>() != null
+        }
+
+    companion object {
+        const val TAG = "SupabaseOccupantDatastore"
+    }
+}

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/supabase/SupabaseOccupantDatastore.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/supabase/SupabaseOccupantDatastore.kt
@@ -4,11 +4,13 @@ import com.cramsan.edifikana.lib.model.occupant.OccupancyStatus
 import com.cramsan.edifikana.lib.model.occupant.OccupantId
 import com.cramsan.edifikana.lib.model.occupant.OccupantType
 import com.cramsan.edifikana.lib.model.organization.OrganizationId
+import com.cramsan.edifikana.lib.model.property.PropertyId
 import com.cramsan.edifikana.lib.model.unit.UnitId
 import com.cramsan.edifikana.lib.model.user.UserId
 import com.cramsan.edifikana.server.datastore.OccupantDatastore
 import com.cramsan.edifikana.server.datastore.supabase.models.OccupantEntity
 import com.cramsan.edifikana.server.datastore.supabase.models.OccupantEntity.CreateOccupantEntity
+import com.cramsan.edifikana.server.datastore.supabase.models.UnitEntity
 import com.cramsan.edifikana.server.service.models.Occupant
 import com.cramsan.framework.annotations.SupabaseModel
 import com.cramsan.framework.core.runSuspendCatching
@@ -20,7 +22,7 @@ import kotlin.time.ExperimentalTime
 /**
  * Supabase implementation of [OccupantDatastore].
  */
-@OptIn(ExperimentalTime::class)
+@OptIn(ExperimentalTime::class, SupabaseModel::class)
 class SupabaseOccupantDatastore(
     private val postgrest: Postgrest,
 ) : OccupantDatastore {
@@ -28,10 +30,8 @@ class SupabaseOccupantDatastore(
     /**
      * Inserts a new occupant row and returns the created [Occupant].
      */
-    @OptIn(SupabaseModel::class)
     override suspend fun createOccupant(
         unitId: UnitId,
-        orgId: OrganizationId,
         userId: UserId?,
         addedBy: UserId?,
         name: String,
@@ -46,6 +46,8 @@ class SupabaseOccupantDatastore(
             unitId = unitId,
             userId = userId,
             addedBy = addedBy,
+            name = name,
+            email = email,
             occupantType = occupantType.name,
             isPrimary = isPrimary,
             startDate = startDate,
@@ -59,7 +61,6 @@ class SupabaseOccupantDatastore(
     /**
      * Retrieves a single occupant by [occupantId]. Returns null if not found or soft-deleted.
      */
-    @OptIn(SupabaseModel::class)
     override suspend fun getOccupant(occupantId: OccupantId): Result<Occupant?> =
         runSuspendCatching(TAG) {
             logD(TAG, "Getting occupant: %s", occupantId)
@@ -74,7 +75,6 @@ class SupabaseOccupantDatastore(
     /**
      * Lists occupants for [unitId]. Filters to ACTIVE status unless [includeInactive] is true.
      */
-    @OptIn(SupabaseModel::class)
     override suspend fun listOccupantsForUnit(
         unitId: UnitId,
         includeInactive: Boolean,
@@ -92,9 +92,37 @@ class SupabaseOccupantDatastore(
     }
 
     /**
+     * Lists occupants across every non-deleted unit in [propertyId].
+     * Filters to ACTIVE status unless [includeInactive] is true.
+     */
+    override suspend fun listOccupantsForProperty(
+        propertyId: PropertyId,
+        includeInactive: Boolean,
+    ): Result<List<Occupant>> = runSuspendCatching(TAG) {
+        logD(TAG, "Listing occupants for property: %s, includeInactive: %s", propertyId, includeInactive)
+        val unitIds = postgrest.from(UnitEntity.COLLECTION).select {
+            filter {
+                UnitEntity::propertyId eq propertyId.propertyId
+                UnitEntity::deletedAt isExact null
+            }
+        }.decodeList<UnitEntity>().map { it.unitId.unitId }
+
+        if (unitIds.isEmpty()) return@runSuspendCatching emptyList()
+
+        postgrest.from(OccupantEntity.COLLECTION).select {
+            filter {
+                isIn("unit_id", unitIds)
+                OccupantEntity::deletedAt isExact null
+                if (!includeInactive) {
+                    OccupantEntity::status eq OccupancyStatus.ACTIVE.name
+                }
+            }
+        }.decodeList<OccupantEntity>().map { it.toOccupant() }
+    }
+
+    /**
      * Sets [is_primary]=false on all active, non-deleted occupants for [unitId].
      */
-    @OptIn(SupabaseModel::class)
     override suspend fun clearPrimaryForUnit(unitId: UnitId): Result<kotlin.Unit> =
         runSuspendCatching(TAG) {
             logD(TAG, "Clearing primary for unit: %s", unitId)
@@ -113,9 +141,10 @@ class SupabaseOccupantDatastore(
     /**
      * Updates an existing occupant. Only non-null parameters are applied. Returns the updated [Occupant].
      */
-    @OptIn(SupabaseModel::class)
     override suspend fun updateOccupant(
         occupantId: OccupantId,
+        name: String?,
+        email: String?,
         occupantType: OccupantType?,
         isPrimary: Boolean?,
         endDate: LocalDate?,
@@ -123,6 +152,8 @@ class SupabaseOccupantDatastore(
     ): Result<Occupant> = runSuspendCatching(TAG) {
         logD(TAG, "Updating occupant: %s", occupantId)
         postgrest.from(OccupantEntity.COLLECTION).update({
+            name?.let { value -> OccupantEntity::name setTo value }
+            email?.let { value -> OccupantEntity::email setTo value }
             occupantType?.let { value -> OccupantEntity::occupantType setTo value.name }
             isPrimary?.let { value -> OccupantEntity::isPrimary setTo value }
             endDate?.let { value -> OccupantEntity::endDate setTo value }
@@ -140,7 +171,6 @@ class SupabaseOccupantDatastore(
      * Soft-removes an occupant: sets [status]=INACTIVE and [end_date]=[today].
      * Does not hard-delete the row. Returns the updated [Occupant].
      */
-    @OptIn(SupabaseModel::class)
     override suspend fun softRemoveOccupant(
         occupantId: OccupantId,
         today: LocalDate,
@@ -161,7 +191,6 @@ class SupabaseOccupantDatastore(
     /**
      * Hard-deletes an occupant row. For integration test cleanup only.
      */
-    @OptIn(SupabaseModel::class)
     override suspend fun purgeOccupant(occupantId: OccupantId): Result<Boolean> =
         runSuspendCatching(TAG) {
             logD(TAG, "Purging occupant: %s", occupantId)

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/supabase/SupabaseOccupantDatastore.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/supabase/SupabaseOccupantDatastore.kt
@@ -3,7 +3,6 @@ package com.cramsan.edifikana.server.datastore.supabase
 import com.cramsan.edifikana.lib.model.occupant.OccupancyStatus
 import com.cramsan.edifikana.lib.model.occupant.OccupantId
 import com.cramsan.edifikana.lib.model.occupant.OccupantType
-import com.cramsan.edifikana.lib.model.organization.OrganizationId
 import com.cramsan.edifikana.lib.model.property.PropertyId
 import com.cramsan.edifikana.lib.model.unit.UnitId
 import com.cramsan.edifikana.lib.model.user.UserId

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/supabase/SupabaseUnitDatastore.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/supabase/SupabaseUnitDatastore.kt
@@ -1,21 +1,16 @@
 package com.cramsan.edifikana.server.datastore.supabase
 
-import com.cramsan.edifikana.lib.model.organization.OrganizationId
 import com.cramsan.edifikana.lib.model.property.PropertyId
 import com.cramsan.edifikana.lib.model.unit.UnitId
 import com.cramsan.edifikana.server.datastore.UnitDatastore
-import com.cramsan.edifikana.server.datastore.supabase.models.OrganizationEntity
 import com.cramsan.edifikana.server.datastore.supabase.models.PropertyEntity
 import com.cramsan.edifikana.server.datastore.supabase.models.UnitEntity
-import com.cramsan.edifikana.server.datastore.supabase.models.UserEntity
-import com.cramsan.edifikana.server.datastore.supabase.models.UserOrganizationMappingEntity
 import com.cramsan.edifikana.server.service.models.Unit
 import com.cramsan.framework.annotations.SupabaseModel
 import com.cramsan.framework.core.runSuspendCatching
 import com.cramsan.framework.logging.logD
 import com.cramsan.framework.utils.exceptions.ClientRequestExceptions
 import io.github.jan.supabase.postgrest.Postgrest
-import io.github.jan.supabase.postgrest.query.Columns
 import kotlin.time.Clock
 
 /**

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/supabase/models/OccupantEntity.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/supabase/models/OccupantEntity.kt
@@ -1,0 +1,73 @@
+package com.cramsan.edifikana.server.datastore.supabase.models
+
+import com.cramsan.edifikana.lib.model.occupant.OccupancyStatus
+import com.cramsan.edifikana.lib.model.occupant.OccupantId
+import com.cramsan.edifikana.lib.model.organization.OrganizationId
+import com.cramsan.edifikana.lib.model.unit.UnitId
+import com.cramsan.edifikana.lib.model.user.UserId
+import com.cramsan.framework.annotations.SupabaseModel
+import kotlinx.datetime.LocalDate
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+/**
+ * Entity representing an occupant row in the `unit_occupants` Supabase table.
+ *
+ * [occupantType] and [status] are stored as UPPER_SNAKE_CASE strings matching the DB enum values.
+ */
+@OptIn(ExperimentalTime::class)
+@Serializable
+@SupabaseModel
+data class OccupantEntity(
+    @SerialName("occupant_id")
+    val occupantId: OccupantId,
+    @SerialName("unit_id")
+    val unitId: UnitId,
+    @SerialName("user_id")
+    val userId: UserId?,
+    @SerialName("added_by")
+    val addedBy: UserId?,
+    @SerialName("occupant_type")
+    val occupantType: String,
+    @SerialName("is_primary")
+    val isPrimary: Boolean,
+    @SerialName("start_date")
+    val startDate: LocalDate,
+    @SerialName("end_date")
+    val endDate: LocalDate?,
+    val status: String,
+    @SerialName("added_at")
+    val addedAt: Instant,
+    @SerialName("deleted_at")
+    val deletedAt: Instant?,
+) {
+    companion object {
+        const val COLLECTION = "unit_occupants"
+    }
+
+    /**
+     * Entity used when inserting a new occupant. Omits auto-generated fields
+     * ([occupantId], [addedAt], [deletedAt]).
+     */
+    @Serializable
+    @SupabaseModel
+    data class CreateOccupantEntity(
+        @SerialName("unit_id")
+        val unitId: UnitId,
+        @SerialName("user_id")
+        val userId: UserId?,
+        @SerialName("added_by")
+        val addedBy: UserId?,
+        @SerialName("occupant_type")
+        val occupantType: String,
+        @SerialName("is_primary")
+        val isPrimary: Boolean,
+        val status: String = OccupancyStatus.ACTIVE.name,
+        @SerialName("start_date")
+        val startDate: LocalDate,
+        @SerialName("end_date")
+        val endDate: LocalDate?,
+    )
+}

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/supabase/models/OccupantEntity.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/supabase/models/OccupantEntity.kt
@@ -2,7 +2,6 @@ package com.cramsan.edifikana.server.datastore.supabase.models
 
 import com.cramsan.edifikana.lib.model.occupant.OccupancyStatus
 import com.cramsan.edifikana.lib.model.occupant.OccupantId
-import com.cramsan.edifikana.lib.model.organization.OrganizationId
 import com.cramsan.edifikana.lib.model.unit.UnitId
 import com.cramsan.edifikana.lib.model.user.UserId
 import com.cramsan.framework.annotations.SupabaseModel

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/supabase/models/OccupantEntity.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/supabase/models/OccupantEntity.kt
@@ -29,6 +29,8 @@ data class OccupantEntity(
     val userId: UserId?,
     @SerialName("added_by")
     val addedBy: UserId?,
+    val name: String,
+    val email: String?,
     @SerialName("occupant_type")
     val occupantType: String,
     @SerialName("is_primary")
@@ -60,6 +62,8 @@ data class OccupantEntity(
         val userId: UserId?,
         @SerialName("added_by")
         val addedBy: UserId?,
+        val name: String,
+        val email: String?,
         @SerialName("occupant_type")
         val occupantType: String,
         @SerialName("is_primary")

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/dependencyinjection/ControllerModule.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/dependencyinjection/ControllerModule.kt
@@ -1,6 +1,7 @@
 package com.cramsan.edifikana.server.dependencyinjection
 
 import com.cramsan.edifikana.server.controller.CommonAreaController
+import com.cramsan.edifikana.server.controller.OccupantController
 import com.cramsan.edifikana.server.controller.PaymentRecordController
 import com.cramsan.edifikana.server.controller.RentConfigController
 import com.cramsan.edifikana.server.controller.TaskController
@@ -42,4 +43,5 @@ internal val ControllerModule = module {
     singleOf(::TaskController) { bind<Controller>() }
     singleOf(::PaymentRecordController) { bind<Controller>() }
     singleOf(::RentConfigController) { bind<Controller>() }
+    singleOf(::OccupantController) { bind<Controller>() }
 }

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/dependencyinjection/DatastoreModule.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/dependencyinjection/DatastoreModule.kt
@@ -2,6 +2,7 @@ package com.cramsan.edifikana.server.dependencyinjection
 
 import com.cramsan.architecture.server.settings.SettingsHolder
 import com.cramsan.edifikana.server.datastore.CommonAreaDatastore
+import com.cramsan.edifikana.server.datastore.OccupantDatastore
 import com.cramsan.edifikana.server.datastore.DocumentDatastore
 import com.cramsan.edifikana.server.datastore.PaymentRecordDatastore
 import com.cramsan.edifikana.server.datastore.RentConfigDatastore
@@ -17,6 +18,7 @@ import com.cramsan.edifikana.server.datastore.TimeCardDatastore
 import com.cramsan.edifikana.server.datastore.UnitDatastore
 import com.cramsan.edifikana.server.datastore.UserDatastore
 import com.cramsan.edifikana.server.datastore.supabase.SupabaseCommonAreaDatastore
+import com.cramsan.edifikana.server.datastore.supabase.SupabaseOccupantDatastore
 import com.cramsan.edifikana.server.datastore.supabase.SupabaseDocumentDatastore
 import com.cramsan.edifikana.server.datastore.supabase.SupabasePaymentRecordDatastore
 import com.cramsan.edifikana.server.datastore.supabase.SupabaseRentConfigDatastore
@@ -140,5 +142,8 @@ val DatastoreModule = module {
     }
     singleOf(::SupabaseRentConfigDatastore) {
         bind<RentConfigDatastore>()
+    }
+    singleOf(::SupabaseOccupantDatastore) {
+        bind<OccupantDatastore>()
     }
 }

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/dependencyinjection/ServicesModule.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/dependencyinjection/ServicesModule.kt
@@ -1,6 +1,7 @@
 package com.cramsan.edifikana.server.dependencyinjection
 
 import com.cramsan.edifikana.server.service.CommonAreaService
+import com.cramsan.edifikana.server.service.OccupantService
 import com.cramsan.edifikana.server.service.PaymentRecordService
 import com.cramsan.edifikana.server.service.RentConfigService
 import com.cramsan.edifikana.server.service.TaskService
@@ -39,4 +40,5 @@ internal val ServicesModule = module {
     singleOf(::TaskService)
     singleOf(::PaymentRecordService)
     singleOf(::RentConfigService)
+    singleOf(::OccupantService)
 }

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/service/OccupantService.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/service/OccupantService.kt
@@ -1,0 +1,157 @@
+package com.cramsan.edifikana.server.service
+
+import com.cramsan.edifikana.lib.model.occupant.OccupancyStatus
+import com.cramsan.edifikana.lib.model.occupant.OccupantId
+import com.cramsan.edifikana.lib.model.occupant.OccupantType
+import com.cramsan.edifikana.lib.model.unit.UnitId
+import com.cramsan.edifikana.lib.model.user.UserId
+import com.cramsan.edifikana.server.datastore.OccupantDatastore
+import com.cramsan.edifikana.server.datastore.UnitDatastore
+import com.cramsan.edifikana.server.service.models.Occupant
+import com.cramsan.framework.logging.logD
+import com.cramsan.framework.utils.exceptions.ClientRequestExceptions.ConflictException
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+
+/**
+ * Service for managing unit occupants. Delegates persistence to [OccupantDatastore].
+ */
+@OptIn(ExperimentalTime::class)
+class OccupantService(
+    private val occupantDatastore: OccupantDatastore,
+    private val unitDatastore: UnitDatastore,
+    private val clock: Clock,
+) {
+
+    /**
+     * Adds a new occupant to a unit.
+     *
+     * If [isPrimary] is true, clears the primary flag on all other active occupants for the unit first.
+     * The org_id is resolved automatically from the unit record.
+     */
+    suspend fun addOccupant(
+        unitId: UnitId,
+        userId: UserId?,
+        addedBy: UserId?,
+        name: String,
+        email: String?,
+        occupantType: OccupantType,
+        isPrimary: Boolean,
+        startDate: LocalDate,
+        endDate: LocalDate?,
+    ): Occupant {
+        logD(TAG, "addOccupant")
+        val unit = unitDatastore.getUnit(unitId).getOrThrow()
+            ?: throw NoSuchElementException("Unit not found: $unitId")
+        if (isPrimary) {
+            occupantDatastore.clearPrimaryForUnit(unitId).getOrThrow()
+        }
+        return occupantDatastore.createOccupant(
+            unitId = unitId,
+            orgId = unit.orgId,
+            userId = userId,
+            addedBy = addedBy,
+            name = name,
+            email = email,
+            occupantType = occupantType,
+            isPrimary = isPrimary,
+            startDate = startDate,
+            endDate = endDate,
+        ).getOrThrow()
+    }
+
+    /**
+     * Retrieves a single occupant by [occupantId]. Returns null if not found.
+     */
+    suspend fun getOccupant(occupantId: OccupantId): Occupant? {
+        logD(TAG, "getOccupant")
+        return occupantDatastore.getOccupant(occupantId).getOrThrow()
+    }
+
+    /**
+     * Lists occupants for [unitId]. Returns active occupants only unless [includeInactive] is true.
+     */
+    suspend fun listOccupantsForUnit(
+        unitId: UnitId,
+        includeInactive: Boolean,
+    ): List<Occupant> {
+        logD(TAG, "listOccupantsForUnit")
+        return occupantDatastore.listOccupantsForUnit(unitId, includeInactive).getOrThrow()
+    }
+
+    /**
+     * Updates an existing occupant.
+     *
+     * If [isPrimary] is being set to true, clears the primary flag on all other active occupants first.
+     * If [isPrimary] is being set to false and this is the only active occupant, rejects with [ConflictException].
+     */
+    suspend fun updateOccupant(
+        occupantId: OccupantId,
+        occupantType: OccupantType?,
+        isPrimary: Boolean?,
+        endDate: LocalDate?,
+        status: OccupancyStatus?,
+    ): Occupant {
+        logD(TAG, "updateOccupant")
+        val existing = occupantDatastore.getOccupant(occupantId).getOrThrow()
+            ?: throw NoSuchElementException("Occupant not found: $occupantId")
+
+        if (isPrimary == true) {
+            occupantDatastore.clearPrimaryForUnit(existing.unitId).getOrThrow()
+        } else if (isPrimary == false && existing.isPrimary) {
+            val activeOccupants = occupantDatastore.listOccupantsForUnit(
+                unitId = existing.unitId,
+                includeInactive = false,
+            ).getOrThrow()
+            if (activeOccupants.size == 1) {
+                throw ConflictException(
+                    "Cannot unset primary on the only active occupant. Designate a new primary first.",
+                )
+            }
+        }
+
+        return occupantDatastore.updateOccupant(
+            occupantId = occupantId,
+            occupantType = occupantType,
+            isPrimary = isPrimary,
+            endDate = endDate,
+            status = status,
+        ).getOrThrow()
+    }
+
+    /**
+     * Soft-removes an occupant: sets status to INACTIVE and end_date to today.
+     *
+     * Rejects with [ConflictException] if the occupant is the primary and other active occupants exist for the unit —
+     * the caller must designate a new primary first.
+     */
+    suspend fun removeOccupant(occupantId: OccupantId): Occupant {
+        logD(TAG, "removeOccupant")
+        val existing = occupantDatastore.getOccupant(occupantId).getOrThrow()
+            ?: throw NoSuchElementException("Occupant not found: $occupantId")
+
+        if (existing.isPrimary) {
+            val activeOccupants = occupantDatastore.listOccupantsForUnit(
+                unitId = existing.unitId,
+                includeInactive = false,
+            ).getOrThrow()
+            val otherActive = activeOccupants.filter { it.id != occupantId }
+            if (otherActive.isNotEmpty()) {
+                throw ConflictException(
+                    "Cannot remove the primary occupant while other active occupants exist. " +
+                        "Designate a new primary first.",
+                )
+            }
+        }
+
+        val today = clock.now().toLocalDateTime(TimeZone.UTC).date
+        return occupantDatastore.softRemoveOccupant(occupantId, today).getOrThrow()
+    }
+
+    companion object {
+        private const val TAG = "OccupantService"
+    }
+}

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/service/OccupantService.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/service/OccupantService.kt
@@ -22,7 +22,6 @@ import kotlin.time.ExperimentalTime
 @OptIn(ExperimentalTime::class)
 class OccupantService(
     private val occupantDatastore: OccupantDatastore,
-    private val unitDatastore: UnitDatastore,
     private val clock: Clock,
 ) {
 
@@ -44,14 +43,11 @@ class OccupantService(
         endDate: LocalDate?,
     ): Occupant {
         logD(TAG, "addOccupant")
-        val unit = unitDatastore.getUnit(unitId).getOrThrow()
-            ?: throw NoSuchElementException("Unit not found: $unitId")
         if (isPrimary) {
             occupantDatastore.clearPrimaryForUnit(unitId).getOrThrow()
         }
         return occupantDatastore.createOccupant(
             unitId = unitId,
-            orgId = unit.orgId,
             userId = userId,
             addedBy = addedBy,
             name = name,
@@ -90,6 +86,8 @@ class OccupantService(
      */
     suspend fun updateOccupant(
         occupantId: OccupantId,
+        name: String?,
+        email: String?,
         occupantType: OccupantType?,
         isPrimary: Boolean?,
         endDate: LocalDate?,
@@ -115,6 +113,8 @@ class OccupantService(
 
         return occupantDatastore.updateOccupant(
             occupantId = occupantId,
+            name = name,
+            email = email,
             occupantType = occupantType,
             isPrimary = isPrimary,
             endDate = endDate,

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/service/OccupantService.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/service/OccupantService.kt
@@ -6,7 +6,6 @@ import com.cramsan.edifikana.lib.model.occupant.OccupantType
 import com.cramsan.edifikana.lib.model.unit.UnitId
 import com.cramsan.edifikana.lib.model.user.UserId
 import com.cramsan.edifikana.server.datastore.OccupantDatastore
-import com.cramsan.edifikana.server.datastore.UnitDatastore
 import com.cramsan.edifikana.server.service.models.Occupant
 import com.cramsan.framework.logging.logD
 import com.cramsan.framework.utils.exceptions.ClientRequestExceptions.ConflictException

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/service/authorization/RBACService.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/service/authorization/RBACService.kt
@@ -7,6 +7,7 @@ import com.cramsan.edifikana.lib.model.eventLog.EventLogEntryId
 import com.cramsan.edifikana.lib.model.organization.OrganizationId
 import com.cramsan.edifikana.lib.model.payment.PaymentRecordId
 import com.cramsan.edifikana.lib.model.property.PropertyId
+import com.cramsan.edifikana.lib.model.occupant.OccupantId
 import com.cramsan.edifikana.lib.model.rent.RentConfigId
 import com.cramsan.edifikana.lib.model.task.TaskId
 import com.cramsan.edifikana.lib.model.timeCard.TimeCardEventId
@@ -14,6 +15,7 @@ import com.cramsan.edifikana.lib.model.unit.UnitId
 import com.cramsan.edifikana.lib.model.user.UserId
 import com.cramsan.edifikana.server.controller.authentication.SupabaseContextPayload
 import com.cramsan.edifikana.server.datastore.CommonAreaDatastore
+import com.cramsan.edifikana.server.datastore.OccupantDatastore
 import com.cramsan.edifikana.server.datastore.DocumentDatastore
 import com.cramsan.edifikana.server.datastore.EmployeeDatastore
 import com.cramsan.edifikana.server.datastore.EventLogDatastore
@@ -46,6 +48,7 @@ class RBACService(
     private val unitDatastore: UnitDatastore,
     private val paymentRecordDatastore: PaymentRecordDatastore,
     private val rentConfigDatastore: RentConfigDatastore,
+    private val occupantDatastore: OccupantDatastore,
 ) {
 
     private val propertyNotFoundException = "ERROR: PROPERTY NOT FOUND!"
@@ -636,6 +639,53 @@ class RBACService(
         val task = taskDatastore.getTask(targetTaskId).getOrThrow()
             ?: return UserRole.UNAUTHORIZED
         return getUserRoleForPropertyAction(context, task.propertyId)
+    }
+
+    /**
+     * Checks if the user has the required role to perform actions on the target occupant.
+     *
+     * @param context The authenticated client context containing user information.
+     * @param targetOccupantId The ID of the target occupant on which the action is to be performed.
+     * @param requiredRole The role required to perform the action.
+     * @return True if the user has the required role, false otherwise.
+     */
+    suspend fun hasRole(
+        context: ClientContext.AuthenticatedClientContext<SupabaseContextPayload>,
+        targetOccupantId: OccupantId,
+        requiredRole: UserRole,
+    ): Boolean {
+        val userRole = getUserRoleForOccupantAction(context, targetOccupantId)
+        return userRole == requiredRole
+    }
+
+    /**
+     * Checks if the user has the required role or higher to perform actions on the target occupant.
+     *
+     * @param context The authenticated client context containing user information.
+     * @param targetOccupantId The ID of the target occupant on which the action is to be performed.
+     * @param requiredRole The minimum role required to perform the action.
+     * @return True if the user has the required role or higher, false otherwise.
+     */
+    suspend fun hasRoleOrHigher(
+        context: ClientContext.AuthenticatedClientContext<SupabaseContextPayload>,
+        targetOccupantId: OccupantId,
+        requiredRole: UserRole,
+    ): Boolean {
+        val userRole = getUserRoleForOccupantAction(context, targetOccupantId)
+        return userRole.level <= requiredRole.level
+    }
+
+    /**
+     * Retrieves the user role for the action being performed on the target occupant.
+     * Resolves through occupant → unit → org.
+     */
+    private suspend fun getUserRoleForOccupantAction(
+        context: ClientContext.AuthenticatedClientContext<SupabaseContextPayload>,
+        targetOccupantId: OccupantId,
+    ): UserRole {
+        val occupant = occupantDatastore.getOccupant(targetOccupantId).getOrThrow()
+            ?: return UserRole.UNAUTHORIZED
+        return getUserRoleForUnitAction(context, occupant.unitId)
     }
 
     companion object {

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/service/models/Occupant.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/service/models/Occupant.kt
@@ -1,28 +1,28 @@
-package com.cramsan.edifikana.lib.model.occupant
+package com.cramsan.edifikana.server.service.models
 
+import com.cramsan.edifikana.lib.model.occupant.OccupancyStatus
+import com.cramsan.edifikana.lib.model.occupant.OccupantId
+import com.cramsan.edifikana.lib.model.occupant.OccupantType
 import com.cramsan.edifikana.lib.model.organization.OrganizationId
 import com.cramsan.edifikana.lib.model.unit.UnitId
 import com.cramsan.edifikana.lib.model.user.UserId
 import kotlinx.datetime.LocalDate
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 /**
- * Domain model representing a unit occupancy record.
- *
- * Timestamp fields (addedAt) are epoch seconds (Long).
- * Date fields (startDate, endDate) use [LocalDate] (date-only, no time component).
+ * Domain model representing a unit occupant record.
  */
-data class OccupantModel(
+@OptIn(ExperimentalTime::class)
+data class Occupant(
     val id: OccupantId,
     val unitId: UnitId,
-    val orgId: OrganizationId,
     val userId: UserId?,
     val addedBy: UserId?,
-    val name: String,
-    val email: String?,
     val occupantType: OccupantType,
     val isPrimary: Boolean,
     val startDate: LocalDate,
     val endDate: LocalDate?,
     val status: OccupancyStatus,
-    val addedAt: Long,
+    val addedAt: Instant,
 )

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/service/models/Occupant.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/service/models/Occupant.kt
@@ -3,7 +3,6 @@ package com.cramsan.edifikana.server.service.models
 import com.cramsan.edifikana.lib.model.occupant.OccupancyStatus
 import com.cramsan.edifikana.lib.model.occupant.OccupantId
 import com.cramsan.edifikana.lib.model.occupant.OccupantType
-import com.cramsan.edifikana.lib.model.organization.OrganizationId
 import com.cramsan.edifikana.lib.model.unit.UnitId
 import com.cramsan.edifikana.lib.model.user.UserId
 import kotlinx.datetime.LocalDate

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/service/models/Occupant.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/service/models/Occupant.kt
@@ -19,6 +19,8 @@ data class Occupant(
     val unitId: UnitId,
     val userId: UserId?,
     val addedBy: UserId?,
+    val name: String,
+    val email: String?,
     val occupantType: OccupantType,
     val isPrimary: Boolean,
     val startDate: LocalDate,

--- a/edifikana/back-end/src/test/kotlin/com/cramsan/edifikana/server/controller/OccupantControllerTest.kt
+++ b/edifikana/back-end/src/test/kotlin/com/cramsan/edifikana/server/controller/OccupantControllerTest.kt
@@ -1,0 +1,190 @@
+@file:OptIn(ExperimentalTime::class)
+
+package com.cramsan.edifikana.server.controller
+
+import com.cramsan.architecture.server.test.startTestKoin
+import com.cramsan.architecture.server.test.testBackEndApplication
+import com.cramsan.edifikana.lib.model.occupant.OccupancyStatus
+import com.cramsan.edifikana.lib.model.occupant.OccupantId
+import com.cramsan.edifikana.lib.model.occupant.OccupantType
+import com.cramsan.edifikana.lib.model.organization.OrganizationId
+import com.cramsan.edifikana.lib.model.unit.UnitId
+import com.cramsan.edifikana.lib.model.user.UserId
+import com.cramsan.edifikana.lib.serialization.createJson
+import com.cramsan.edifikana.server.controller.authentication.SupabaseContextPayload
+import com.cramsan.edifikana.server.dependencyinjection.TestControllerModule
+import com.cramsan.edifikana.server.dependencyinjection.TestServiceModule
+import com.cramsan.edifikana.server.dependencyinjection.testApplicationModule
+import com.cramsan.edifikana.server.service.OccupantService
+import com.cramsan.edifikana.server.service.authorization.RBACService
+import com.cramsan.edifikana.server.service.models.Occupant
+import com.cramsan.edifikana.server.service.models.UserRole
+import com.cramsan.edifikana.server.utils.readFileContent
+import com.cramsan.framework.core.ktor.auth.ClientContext
+import com.cramsan.framework.core.ktor.auth.ContextRetriever
+import com.cramsan.framework.test.CoroutineTest
+import com.cramsan.framework.utils.exceptions.ClientRequestExceptions.ConflictException
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.datetime.LocalDate
+import org.koin.core.context.stopKoin
+import org.koin.test.KoinTest
+import org.koin.test.get
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+class OccupantControllerTest : CoroutineTest(), KoinTest {
+
+    @BeforeTest
+    fun setupTest() {
+        startTestKoin(
+            testApplicationModule(createJson()),
+            TestControllerModule,
+            TestServiceModule,
+        )
+    }
+
+    @AfterTest
+    fun cleanUp() {
+        stopKoin()
+    }
+
+    // -------------------------------------------------------------------------
+    // Resident RBAC — getOccupant
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `getOccupant returns occupant when Resident is reading their own record`() = testBackEndApplication {
+        val occupantId = OccupantId("occupant123")
+        val callerId = UserId("user123")
+        val occupantService = get<OccupantService>()
+        val rbacService = get<RBACService>()
+        val contextRetriever = get<ContextRetriever<SupabaseContextPayload>>()
+        val context = ClientContext.AuthenticatedClientContext(
+            SupabaseContextPayload(userInfo = mockk(), userId = callerId)
+        )
+        val expectedResponse = readFileContent("requests/get_occupant_response.json")
+
+        coEvery { contextRetriever.getContext(any()) }.answers { context }
+        coEvery { rbacService.hasRoleOrHigher(context, occupantId, UserRole.EMPLOYEE) }.answers { false }
+        coEvery { occupantService.getOccupant(occupantId) }.answers {
+            Occupant(
+                id = occupantId,
+                unitId = UnitId("unit123"),
+                userId = callerId,
+                addedBy = callerId,
+                occupantType = OccupantType.TENANT,
+                isPrimary = true,
+                startDate = LocalDate(2026, 1, 1),
+                endDate = null,
+                status = OccupancyStatus.ACTIVE,
+                addedAt = Instant.fromEpochSeconds(0),
+            )
+        }
+
+        val response = client.get("occupants/occupant123")
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals(expectedResponse, response.bodyAsText())
+    }
+
+    @Test
+    fun `getOccupant returns 404 when Resident tries to read another user's record`() = testBackEndApplication {
+        val occupantId = OccupantId("occupant123")
+        val callerId = UserId("user123")
+        val occupantService = get<OccupantService>()
+        val rbacService = get<RBACService>()
+        val contextRetriever = get<ContextRetriever<SupabaseContextPayload>>()
+        val context = ClientContext.AuthenticatedClientContext(
+            SupabaseContextPayload(userInfo = mockk(), userId = callerId)
+        )
+
+        coEvery { contextRetriever.getContext(any()) }.answers { context }
+        coEvery { rbacService.hasRoleOrHigher(context, occupantId, UserRole.EMPLOYEE) }.answers { false }
+        coEvery { occupantService.getOccupant(occupantId) }.answers {
+            Occupant(
+                id = occupantId,
+                unitId = UnitId("unit123"),
+                userId = UserId("different-user"),
+                addedBy = callerId,
+                occupantType = OccupantType.TENANT,
+                isPrimary = true,
+                startDate = LocalDate(2026, 1, 1),
+                endDate = null,
+                status = OccupancyStatus.ACTIVE,
+                addedAt = Instant.fromEpochSeconds(0),
+            )
+        }
+
+        val response = client.get("occupants/occupant123")
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+
+    @Test
+    fun `getOccupant returns 404 when Resident tries to read an occupant with no linked user`() = testBackEndApplication {
+        val occupantId = OccupantId("occupant123")
+        val callerId = UserId("user123")
+        val occupantService = get<OccupantService>()
+        val rbacService = get<RBACService>()
+        val contextRetriever = get<ContextRetriever<SupabaseContextPayload>>()
+        val context = ClientContext.AuthenticatedClientContext(
+            SupabaseContextPayload(userInfo = mockk(), userId = callerId)
+        )
+
+        coEvery { contextRetriever.getContext(any()) }.answers { context }
+        coEvery { rbacService.hasRoleOrHigher(context, occupantId, UserRole.EMPLOYEE) }.answers { false }
+        coEvery { occupantService.getOccupant(occupantId) }.answers {
+            Occupant(
+                id = occupantId,
+                unitId = UnitId("unit123"),
+                userId = null,
+                addedBy = callerId,
+                occupantType = OccupantType.TENANT,
+                isPrimary = true,
+                startDate = LocalDate(2026, 1, 1),
+                endDate = null,
+                status = OccupancyStatus.ACTIVE,
+                addedAt = Instant.fromEpochSeconds(0),
+            )
+        }
+
+        val response = client.get("occupants/occupant123")
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+
+    // -------------------------------------------------------------------------
+    // removeOccupant — 409 soft-remove guard
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `removeOccupant returns 409 when primary occupant has other active occupants`() = testBackEndApplication {
+        val occupantId = OccupantId("occupant123")
+        val callerId = UserId("user123")
+        val occupantService = get<OccupantService>()
+        val rbacService = get<RBACService>()
+        val contextRetriever = get<ContextRetriever<SupabaseContextPayload>>()
+        val context = ClientContext.AuthenticatedClientContext(
+            SupabaseContextPayload(userInfo = mockk(), userId = callerId)
+        )
+
+        coEvery { contextRetriever.getContext(any()) }.answers { context }
+        coEvery { rbacService.hasRoleOrHigher(context, occupantId, UserRole.ADMIN) }.answers { true }
+        coEvery { occupantService.removeOccupant(occupantId) }.throws(
+            ConflictException("Cannot remove the primary occupant while other active occupants exist.")
+        )
+
+        val response = client.delete("occupants/occupant123")
+
+        assertEquals(HttpStatusCode.Conflict, response.status)
+    }
+}

--- a/edifikana/back-end/src/test/kotlin/com/cramsan/edifikana/server/controller/OccupantControllerTest.kt
+++ b/edifikana/back-end/src/test/kotlin/com/cramsan/edifikana/server/controller/OccupantControllerTest.kt
@@ -26,9 +26,14 @@ import com.cramsan.framework.test.CoroutineTest
 import com.cramsan.framework.utils.exceptions.ClientRequestExceptions.ConflictException
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.datetime.LocalDate
 import org.koin.core.context.stopKoin
@@ -58,6 +63,74 @@ class OccupantControllerTest : CoroutineTest(), KoinTest {
     }
 
     // -------------------------------------------------------------------------
+    // createOccupant — name/email round-trip
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `createOccupant persists name and email on the response`() = testBackEndApplication {
+        val unitId = UnitId("unit123")
+        val callerId = UserId("user123")
+        val occupantService = get<OccupantService>()
+        val rbacService = get<RBACService>()
+        val contextRetriever = get<ContextRetriever<SupabaseContextPayload>>()
+        val context = ClientContext.AuthenticatedClientContext(
+            SupabaseContextPayload(userInfo = mockk(), userId = callerId)
+        )
+        val requestBody = readFileContent("requests/create_occupant_request.json")
+        val expectedResponse = readFileContent("requests/get_occupant_response.json")
+
+        coEvery { contextRetriever.getContext(any()) } returns context
+        coEvery { rbacService.hasRoleOrHigher(context, unitId, UserRole.ADMIN) } returns true
+        coEvery {
+            occupantService.addOccupant(
+                unitId = unitId,
+                userId = callerId,
+                addedBy = callerId,
+                name = "Jane Doe",
+                email = "jane@example.com",
+                occupantType = OccupantType.TENANT,
+                isPrimary = true,
+                startDate = LocalDate(2026, 1, 1),
+                endDate = null,
+            )
+        } returns Occupant(
+            id = OccupantId("occupant123"),
+            unitId = unitId,
+            userId = callerId,
+            addedBy = callerId,
+            name = "Jane Doe",
+            email = "jane@example.com",
+            occupantType = OccupantType.TENANT,
+            isPrimary = true,
+            startDate = LocalDate(2026, 1, 1),
+            endDate = null,
+            status = OccupancyStatus.ACTIVE,
+            addedAt = Instant.fromEpochSeconds(0),
+        )
+
+        val response = client.post("occupants") {
+            setBody(requestBody)
+            contentType(ContentType.Application.Json)
+        }
+
+        coVerify {
+            occupantService.addOccupant(
+                unitId = unitId,
+                userId = callerId,
+                addedBy = callerId,
+                name = "Jane Doe",
+                email = "jane@example.com",
+                occupantType = OccupantType.TENANT,
+                isPrimary = true,
+                startDate = LocalDate(2026, 1, 1),
+                endDate = null,
+            )
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals(expectedResponse, response.bodyAsText())
+    }
+
+    // -------------------------------------------------------------------------
     // Resident RBAC — getOccupant
     // -------------------------------------------------------------------------
 
@@ -81,6 +154,8 @@ class OccupantControllerTest : CoroutineTest(), KoinTest {
                 unitId = UnitId("unit123"),
                 userId = callerId,
                 addedBy = callerId,
+                name = "Jane Doe",
+                email = "jane@example.com",
                 occupantType = OccupantType.TENANT,
                 isPrimary = true,
                 startDate = LocalDate(2026, 1, 1),
@@ -115,6 +190,8 @@ class OccupantControllerTest : CoroutineTest(), KoinTest {
                 unitId = UnitId("unit123"),
                 userId = UserId("different-user"),
                 addedBy = callerId,
+                name = "Other Person",
+                email = null,
                 occupantType = OccupantType.TENANT,
                 isPrimary = true,
                 startDate = LocalDate(2026, 1, 1),
@@ -148,6 +225,8 @@ class OccupantControllerTest : CoroutineTest(), KoinTest {
                 unitId = UnitId("unit123"),
                 userId = null,
                 addedBy = callerId,
+                name = "Name Only",
+                email = null,
                 occupantType = OccupantType.TENANT,
                 isPrimary = true,
                 startDate = LocalDate(2026, 1, 1),

--- a/edifikana/back-end/src/test/kotlin/com/cramsan/edifikana/server/controller/OccupantControllerTest.kt
+++ b/edifikana/back-end/src/test/kotlin/com/cramsan/edifikana/server/controller/OccupantControllerTest.kt
@@ -7,7 +7,6 @@ import com.cramsan.architecture.server.test.testBackEndApplication
 import com.cramsan.edifikana.lib.model.occupant.OccupancyStatus
 import com.cramsan.edifikana.lib.model.occupant.OccupantId
 import com.cramsan.edifikana.lib.model.occupant.OccupantType
-import com.cramsan.edifikana.lib.model.organization.OrganizationId
 import com.cramsan.edifikana.lib.model.unit.UnitId
 import com.cramsan.edifikana.lib.model.user.UserId
 import com.cramsan.edifikana.lib.serialization.createJson

--- a/edifikana/back-end/src/test/kotlin/com/cramsan/edifikana/server/dependencyinjection/TestModule.kt
+++ b/edifikana/back-end/src/test/kotlin/com/cramsan/edifikana/server/dependencyinjection/TestModule.kt
@@ -1,6 +1,7 @@
 package com.cramsan.edifikana.server.dependencyinjection
 
 import com.cramsan.edifikana.server.controller.CommonAreaController
+import com.cramsan.edifikana.server.controller.OccupantController
 import com.cramsan.edifikana.server.controller.PaymentRecordController
 import com.cramsan.edifikana.server.controller.RentConfigController
 import com.cramsan.edifikana.server.controller.TaskController
@@ -16,6 +17,7 @@ import com.cramsan.edifikana.server.controller.TimeCardController
 import com.cramsan.edifikana.server.controller.UnitController
 import com.cramsan.edifikana.server.controller.UserController
 import com.cramsan.edifikana.server.service.CommonAreaService
+import com.cramsan.edifikana.server.service.OccupantService
 import com.cramsan.edifikana.server.service.PaymentRecordService
 import com.cramsan.edifikana.server.service.RentConfigService
 import com.cramsan.edifikana.server.service.TaskService
@@ -57,6 +59,7 @@ internal val TestControllerModule = module {
     singleOf(::UnitController) { bind<Controller>() }
     singleOf(::PaymentRecordController) { bind<Controller>() }
     singleOf(::RentConfigController) { bind<Controller>() }
+    singleOf(::OccupantController) { bind<Controller>() }
 }
 
 /**
@@ -78,6 +81,7 @@ internal val TestServiceModule = module {
     single<TaskService> { mockk() }
     single<PaymentRecordService> { mockk() }
     single<RentConfigService> { mockk() }
+    single<OccupantService> { mockk() }
 }
 
 internal fun testApplicationModule(json: Json) = module {

--- a/edifikana/back-end/src/test/kotlin/com/cramsan/edifikana/server/service/OccupantServiceTest.kt
+++ b/edifikana/back-end/src/test/kotlin/com/cramsan/edifikana/server/service/OccupantServiceTest.kt
@@ -1,0 +1,196 @@
+@file:OptIn(ExperimentalTime::class)
+
+package com.cramsan.edifikana.server.service
+
+import com.cramsan.edifikana.lib.model.occupant.OccupancyStatus
+import com.cramsan.edifikana.lib.model.occupant.OccupantId
+import com.cramsan.edifikana.lib.model.occupant.OccupantType
+import com.cramsan.edifikana.lib.model.organization.OrganizationId
+import com.cramsan.edifikana.lib.model.unit.UnitId
+import com.cramsan.edifikana.server.datastore.OccupantDatastore
+import com.cramsan.edifikana.server.datastore.UnitDatastore
+import com.cramsan.edifikana.server.service.models.Occupant
+import com.cramsan.framework.logging.EventLogger
+import com.cramsan.framework.logging.implementation.PassthroughEventLogger
+import com.cramsan.framework.logging.implementation.StdOutEventLoggerDelegate
+import com.cramsan.framework.utils.exceptions.ClientRequestExceptions.ConflictException
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.LocalDate
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.core.context.stopKoin
+import kotlin.test.AfterTest
+import kotlin.test.assertFailsWith
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+@OptIn(ExperimentalTime::class)
+class OccupantServiceTest {
+
+    private lateinit var occupantDatastore: OccupantDatastore
+    private lateinit var unitDatastore: UnitDatastore
+    private lateinit var clock: Clock
+    private lateinit var occupantService: OccupantService
+
+    private val unitId = UnitId("unit-1")
+    private val orgId = OrganizationId("org-1")
+    private val occupantId = OccupantId("occ-1")
+
+    @BeforeEach
+    fun setUp() {
+        EventLogger.setInstance(PassthroughEventLogger(StdOutEventLoggerDelegate()))
+        occupantDatastore = mockk()
+        unitDatastore = mockk()
+        clock = mockk()
+        every { clock.now() } returns Instant.fromEpochSeconds(1_700_000_000)
+        occupantService = OccupantService(occupantDatastore, unitDatastore, clock)
+    }
+
+    @AfterTest
+    fun cleanUp() {
+        stopKoin()
+    }
+
+    private fun makeOccupant(
+        id: OccupantId = occupantId,
+        isPrimary: Boolean = false,
+        status: OccupancyStatus = OccupancyStatus.ACTIVE,
+    ): Occupant = Occupant(
+        id = id,
+        unitId = unitId,
+        userId = null,
+        addedBy = null,
+        occupantType = OccupantType.TENANT,
+        isPrimary = isPrimary,
+        startDate = LocalDate(2026, 1, 1),
+        endDate = null,
+        status = status,
+        addedAt = Instant.fromEpochSeconds(1_700_000_000),
+    )
+
+    // -------------------------------------------------------------------------
+    // removeOccupant — 409 guard
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `removeOccupant throws ConflictException when removing primary while other active occupants exist`() = runTest {
+        val primary = makeOccupant(isPrimary = true)
+        val other = makeOccupant(id = OccupantId("occ-2"), isPrimary = false)
+
+        coEvery { occupantDatastore.getOccupant(occupantId) } returns Result.success(primary)
+        coEvery {
+            occupantDatastore.listOccupantsForUnit(unitId, includeInactive = false)
+        } returns Result.success(listOf(primary, other))
+
+        assertFailsWith<ConflictException> {
+            occupantService.removeOccupant(occupantId)
+        }
+    }
+
+    @Test
+    fun `removeOccupant succeeds when primary is the only active occupant`() = runTest {
+        val primary = makeOccupant(isPrimary = true)
+        val removed = makeOccupant(isPrimary = true, status = OccupancyStatus.INACTIVE)
+
+        coEvery { occupantDatastore.getOccupant(occupantId) } returns Result.success(primary)
+        coEvery {
+            occupantDatastore.listOccupantsForUnit(unitId, includeInactive = false)
+        } returns Result.success(listOf(primary))
+        coEvery {
+            occupantDatastore.softRemoveOccupant(occupantId, any())
+        } returns Result.success(removed)
+
+        val result = occupantService.removeOccupant(occupantId)
+        coVerify { occupantDatastore.softRemoveOccupant(occupantId, any()) }
+        assert(result.status == OccupancyStatus.INACTIVE)
+    }
+
+    @Test
+    fun `removeOccupant succeeds for a non-primary occupant without checking active count`() = runTest {
+        val nonPrimary = makeOccupant(isPrimary = false)
+        val removed = makeOccupant(isPrimary = false, status = OccupancyStatus.INACTIVE)
+
+        coEvery { occupantDatastore.getOccupant(occupantId) } returns Result.success(nonPrimary)
+        coEvery {
+            occupantDatastore.softRemoveOccupant(occupantId, any())
+        } returns Result.success(removed)
+
+        occupantService.removeOccupant(occupantId)
+        coVerify { occupantDatastore.softRemoveOccupant(occupantId, any()) }
+    }
+
+    // -------------------------------------------------------------------------
+    // updateOccupant — unset-primary guard
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `updateOccupant throws ConflictException when unsetting primary on the only active occupant`() = runTest {
+        val existing = makeOccupant(isPrimary = true)
+
+        coEvery { occupantDatastore.getOccupant(occupantId) } returns Result.success(existing)
+        coEvery {
+            occupantDatastore.listOccupantsForUnit(unitId, includeInactive = false)
+        } returns Result.success(listOf(existing))
+
+        assertFailsWith<ConflictException> {
+            occupantService.updateOccupant(
+                occupantId = occupantId,
+                occupantType = null,
+                isPrimary = false,
+                endDate = null,
+                status = null,
+            )
+        }
+    }
+
+    @Test
+    fun `updateOccupant allows unsetting primary when multiple active occupants exist`() = runTest {
+        val existing = makeOccupant(isPrimary = true)
+        val other = makeOccupant(id = OccupantId("occ-2"), isPrimary = false)
+        val updated = makeOccupant(isPrimary = false)
+
+        coEvery { occupantDatastore.getOccupant(occupantId) } returns Result.success(existing)
+        coEvery {
+            occupantDatastore.listOccupantsForUnit(unitId, includeInactive = false)
+        } returns Result.success(listOf(existing, other))
+        coEvery {
+            occupantDatastore.updateOccupant(occupantId, null, false, null, null)
+        } returns Result.success(updated)
+
+        val result = occupantService.updateOccupant(
+            occupantId = occupantId,
+            occupantType = null,
+            isPrimary = false,
+            endDate = null,
+            status = null,
+        )
+        assert(!result.isPrimary)
+    }
+
+    @Test
+    fun `updateOccupant clears primary for unit when setting isPrimary to true`() = runTest {
+        val existing = makeOccupant(isPrimary = false)
+        val updated = makeOccupant(isPrimary = true)
+
+        coEvery { occupantDatastore.getOccupant(occupantId) } returns Result.success(existing)
+        coEvery { occupantDatastore.clearPrimaryForUnit(unitId) } returns Result.success(Unit)
+        coEvery {
+            occupantDatastore.updateOccupant(occupantId, null, true, null, null)
+        } returns Result.success(updated)
+
+        val result = occupantService.updateOccupant(
+            occupantId = occupantId,
+            occupantType = null,
+            isPrimary = true,
+            endDate = null,
+            status = null,
+        )
+        coVerify { occupantDatastore.clearPrimaryForUnit(unitId) }
+        assert(result.isPrimary)
+    }
+}

--- a/edifikana/back-end/src/test/kotlin/com/cramsan/edifikana/server/service/OccupantServiceTest.kt
+++ b/edifikana/back-end/src/test/kotlin/com/cramsan/edifikana/server/service/OccupantServiceTest.kt
@@ -8,7 +8,6 @@ import com.cramsan.edifikana.lib.model.occupant.OccupantType
 import com.cramsan.edifikana.lib.model.organization.OrganizationId
 import com.cramsan.edifikana.lib.model.unit.UnitId
 import com.cramsan.edifikana.server.datastore.OccupantDatastore
-import com.cramsan.edifikana.server.datastore.UnitDatastore
 import com.cramsan.edifikana.server.service.models.Occupant
 import com.cramsan.framework.logging.EventLogger
 import com.cramsan.framework.logging.implementation.PassthroughEventLogger
@@ -33,7 +32,6 @@ import kotlin.time.Instant
 class OccupantServiceTest {
 
     private lateinit var occupantDatastore: OccupantDatastore
-    private lateinit var unitDatastore: UnitDatastore
     private lateinit var clock: Clock
     private lateinit var occupantService: OccupantService
 
@@ -45,10 +43,9 @@ class OccupantServiceTest {
     fun setUp() {
         EventLogger.setInstance(PassthroughEventLogger(StdOutEventLoggerDelegate()))
         occupantDatastore = mockk()
-        unitDatastore = mockk()
         clock = mockk()
         every { clock.now() } returns Instant.fromEpochSeconds(1_700_000_000)
-        occupantService = OccupantService(occupantDatastore, unitDatastore, clock)
+        occupantService = OccupantService(occupantDatastore, clock)
     }
 
     @AfterTest
@@ -65,6 +62,8 @@ class OccupantServiceTest {
         unitId = unitId,
         userId = null,
         addedBy = null,
+        name = "Test Occupant",
+        email = null,
         occupantType = OccupantType.TENANT,
         isPrimary = isPrimary,
         startDate = LocalDate(2026, 1, 1),
@@ -140,6 +139,8 @@ class OccupantServiceTest {
         assertFailsWith<ConflictException> {
             occupantService.updateOccupant(
                 occupantId = occupantId,
+                name = null,
+                email = null,
                 occupantType = null,
                 isPrimary = false,
                 endDate = null,
@@ -159,11 +160,13 @@ class OccupantServiceTest {
             occupantDatastore.listOccupantsForUnit(unitId, includeInactive = false)
         } returns Result.success(listOf(existing, other))
         coEvery {
-            occupantDatastore.updateOccupant(occupantId, null, false, null, null)
+            occupantDatastore.updateOccupant(occupantId, null, null, null, false, null, null)
         } returns Result.success(updated)
 
         val result = occupantService.updateOccupant(
             occupantId = occupantId,
+            name = null,
+            email = null,
             occupantType = null,
             isPrimary = false,
             endDate = null,
@@ -180,11 +183,13 @@ class OccupantServiceTest {
         coEvery { occupantDatastore.getOccupant(occupantId) } returns Result.success(existing)
         coEvery { occupantDatastore.clearPrimaryForUnit(unitId) } returns Result.success(Unit)
         coEvery {
-            occupantDatastore.updateOccupant(occupantId, null, true, null, null)
+            occupantDatastore.updateOccupant(occupantId, null, null, null, true, null, null)
         } returns Result.success(updated)
 
         val result = occupantService.updateOccupant(
             occupantId = occupantId,
+            name = null,
+            email = null,
             occupantType = null,
             isPrimary = true,
             endDate = null,

--- a/edifikana/back-end/src/test/kotlin/com/cramsan/edifikana/server/service/UnitServiceTest.kt
+++ b/edifikana/back-end/src/test/kotlin/com/cramsan/edifikana/server/service/UnitServiceTest.kt
@@ -1,6 +1,5 @@
 package com.cramsan.edifikana.server.service
 
-import com.cramsan.edifikana.lib.model.organization.OrganizationId
 import com.cramsan.edifikana.lib.model.property.PropertyId
 import com.cramsan.edifikana.lib.model.unit.UnitId
 import com.cramsan.edifikana.server.datastore.UnitDatastore

--- a/edifikana/back-end/src/test/kotlin/com/cramsan/edifikana/server/service/authorization/RBACServiceTest.kt
+++ b/edifikana/back-end/src/test/kotlin/com/cramsan/edifikana/server/service/authorization/RBACServiceTest.kt
@@ -7,6 +7,7 @@ import com.cramsan.edifikana.lib.model.property.PropertyId
 import com.cramsan.edifikana.lib.model.user.UserId
 import com.cramsan.edifikana.server.controller.authentication.SupabaseContextPayload
 import com.cramsan.edifikana.server.datastore.CommonAreaDatastore
+import com.cramsan.edifikana.server.datastore.OccupantDatastore
 import com.cramsan.edifikana.server.datastore.DocumentDatastore
 import com.cramsan.edifikana.server.datastore.EmployeeDatastore
 import com.cramsan.edifikana.server.datastore.PaymentRecordDatastore
@@ -54,6 +55,7 @@ class RBACServiceTest {
     private lateinit var unitDatastore: UnitDatastore
     private lateinit var paymentRecordDatastore: PaymentRecordDatastore
     private lateinit var rentConfigDatastore: RentConfigDatastore
+    private lateinit var occupantDatastore: OccupantDatastore
     private lateinit var rbac: RBACService
 
     @BeforeEach
@@ -70,6 +72,7 @@ class RBACServiceTest {
         taskDatastore = mockk()
         paymentRecordDatastore = mockk()
         rentConfigDatastore = mockk()
+        occupantDatastore = mockk()
         rbac = RBACService(
             propertyDatastore,
             orgDatastore,
@@ -82,6 +85,7 @@ class RBACServiceTest {
             unitDatastore,
             paymentRecordDatastore,
             rentConfigDatastore,
+            occupantDatastore,
         )
     }
 

--- a/edifikana/back-end/src/test/resources/requests/create_occupant_request.json
+++ b/edifikana/back-end/src/test/resources/requests/create_occupant_request.json
@@ -1,14 +1,10 @@
 {
-    "occupant_id": "occupant123",
     "unit_id": "unit123",
     "user_id": "user123",
-    "added_by": "user123",
     "name": "Jane Doe",
     "email": "jane@example.com",
     "occupant_type": "TENANT",
     "is_primary": true,
     "start_date": "2026-01-01",
-    "end_date": null,
-    "status": "ACTIVE",
-    "added_at": "1970-01-01T00:00:00Z"
+    "end_date": null
 }

--- a/edifikana/back-end/src/test/resources/requests/get_occupant_response.json
+++ b/edifikana/back-end/src/test/resources/requests/get_occupant_response.json
@@ -1,0 +1,12 @@
+{
+    "occupant_id": "occupant123",
+    "unit_id": "unit123",
+    "user_id": "user123",
+    "added_by": "user123",
+    "occupant_type": "TENANT",
+    "is_primary": true,
+    "start_date": "2026-01-01",
+    "end_date": null,
+    "status": "ACTIVE",
+    "added_at": 0
+}

--- a/edifikana/back-end/src/test/resources/requests/get_occupant_response.json
+++ b/edifikana/back-end/src/test/resources/requests/get_occupant_response.json
@@ -8,5 +8,5 @@
     "start_date": "2026-01-01",
     "end_date": null,
     "status": "ACTIVE",
-    "added_at": 0
+    "added_at": "1970-01-01T00:00:00Z"
 }

--- a/edifikana/back-end/supabase/migrations/20260424000001_add_name_email_to_unit_occupants.sql
+++ b/edifikana/back-end/supabase/migrations/20260424000001_add_name_email_to_unit_occupants.sql
@@ -1,0 +1,15 @@
+-- ============================================================================
+-- Migration: Add name and email columns to unit_occupants
+-- Issue: https://github.com/CodeHavenX/MonoRepo/issues/419
+-- ============================================================================
+-- The unit_occupants table needs to capture the occupant's display name and
+-- contact email so that name-only occupants (no linked user_id) are
+-- representable, and so that the values shown in the UI are stable even when
+-- a linked user later renames themselves. The values are written once at
+-- occupant-add time and updated explicitly via the update endpoint; they are
+-- not rehydrated from the users table on read.
+-- ============================================================================
+
+ALTER TABLE unit_occupants
+    ADD COLUMN name  TEXT NOT NULL DEFAULT '',
+    ADD COLUMN email TEXT;

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/occupant/CreateOccupantNetworkRequest.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/occupant/CreateOccupantNetworkRequest.kt
@@ -18,6 +18,8 @@ import kotlinx.serialization.Serializable
 data class CreateOccupantNetworkRequest(
     @SerialName("unit_id") val unitId: UnitId,
     @SerialName("user_id") val userId: UserId?,
+    val name: String,
+    val email: String?,
     @SerialName("occupant_type") val occupantType: OccupantType,
     @SerialName("is_primary") val isPrimary: Boolean,
     @SerialName("start_date") val startDate: String,

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/occupant/CreateOccupantNetworkRequest.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/occupant/CreateOccupantNetworkRequest.kt
@@ -5,13 +5,12 @@ import com.cramsan.edifikana.lib.model.unit.UnitId
 import com.cramsan.edifikana.lib.model.user.UserId
 import com.cramsan.framework.annotations.NetworkModel
 import com.cramsan.framework.annotations.api.RequestBody
+import kotlinx.datetime.LocalDate
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
  * Network request to create a new unit occupant record.
- *
- * Date fields (startDate, endDate) are ISO 8601 strings ("YYYY-MM-DD").
  */
 @NetworkModel
 @Serializable
@@ -22,6 +21,6 @@ data class CreateOccupantNetworkRequest(
     val email: String?,
     @SerialName("occupant_type") val occupantType: OccupantType,
     @SerialName("is_primary") val isPrimary: Boolean,
-    @SerialName("start_date") val startDate: String,
-    @SerialName("end_date") val endDate: String?,
+    @SerialName("start_date") val startDate: LocalDate,
+    @SerialName("end_date") val endDate: LocalDate?,
 ) : RequestBody

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/occupant/GetOccupantsForUnitQueryParams.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/occupant/GetOccupantsForUnitQueryParams.kt
@@ -1,0 +1,17 @@
+package com.cramsan.edifikana.lib.model.network.occupant
+
+import com.cramsan.edifikana.lib.model.unit.UnitId
+import com.cramsan.framework.annotations.NetworkModel
+import com.cramsan.framework.annotations.api.QueryParam
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Query parameters for listing occupants for a unit.
+ */
+@NetworkModel
+@Serializable
+data class GetOccupantsForUnitQueryParams(
+    @SerialName("unit_id") val unitId: UnitId,
+    @SerialName("include_inactive") val includeInactive: Boolean = false,
+) : QueryParam

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/occupant/OccupantListNetworkResponse.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/occupant/OccupantListNetworkResponse.kt
@@ -1,0 +1,14 @@
+package com.cramsan.edifikana.lib.model.network.occupant
+
+import com.cramsan.framework.annotations.NetworkModel
+import com.cramsan.framework.annotations.api.ResponseBody
+import kotlinx.serialization.Serializable
+
+/**
+ * Network response containing a list of occupant records.
+ */
+@NetworkModel
+@Serializable
+data class OccupantListNetworkResponse(
+    val occupants: List<OccupantNetworkResponse>,
+) : ResponseBody

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/occupant/OccupantNetworkResponse.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/occupant/OccupantNetworkResponse.kt
@@ -3,7 +3,6 @@ package com.cramsan.edifikana.lib.model.network.occupant
 import com.cramsan.edifikana.lib.model.occupant.OccupancyStatus
 import com.cramsan.edifikana.lib.model.occupant.OccupantId
 import com.cramsan.edifikana.lib.model.occupant.OccupantType
-import com.cramsan.edifikana.lib.model.organization.OrganizationId
 import com.cramsan.edifikana.lib.model.unit.UnitId
 import com.cramsan.edifikana.lib.model.user.UserId
 import com.cramsan.framework.annotations.NetworkModel
@@ -22,11 +21,8 @@ import kotlinx.serialization.Serializable
 data class OccupantNetworkResponse(
     @SerialName("occupant_id") val id: OccupantId,
     @SerialName("unit_id") val unitId: UnitId,
-    @SerialName("org_id") val orgId: OrganizationId,
     @SerialName("user_id") val userId: UserId?,
     @SerialName("added_by") val addedBy: UserId?,
-    val name: String,
-    val email: String?,
     @SerialName("occupant_type") val occupantType: OccupantType,
     @SerialName("is_primary") val isPrimary: Boolean,
     @SerialName("start_date") val startDate: String,

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/occupant/OccupantNetworkResponse.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/occupant/OccupantNetworkResponse.kt
@@ -3,6 +3,7 @@ package com.cramsan.edifikana.lib.model.network.occupant
 import com.cramsan.edifikana.lib.model.occupant.OccupancyStatus
 import com.cramsan.edifikana.lib.model.occupant.OccupantId
 import com.cramsan.edifikana.lib.model.occupant.OccupantType
+import com.cramsan.edifikana.lib.model.organization.OrganizationId
 import com.cramsan.edifikana.lib.model.unit.UnitId
 import com.cramsan.edifikana.lib.model.user.UserId
 import com.cramsan.framework.annotations.NetworkModel
@@ -21,8 +22,11 @@ import kotlinx.serialization.Serializable
 data class OccupantNetworkResponse(
     @SerialName("occupant_id") val id: OccupantId,
     @SerialName("unit_id") val unitId: UnitId,
+    @SerialName("org_id") val orgId: OrganizationId,
     @SerialName("user_id") val userId: UserId?,
     @SerialName("added_by") val addedBy: UserId?,
+    val name: String,
+    val email: String?,
     @SerialName("occupant_type") val occupantType: OccupantType,
     @SerialName("is_primary") val isPrimary: Boolean,
     @SerialName("start_date") val startDate: String,

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/occupant/OccupantNetworkResponse.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/occupant/OccupantNetworkResponse.kt
@@ -7,15 +7,16 @@ import com.cramsan.edifikana.lib.model.unit.UnitId
 import com.cramsan.edifikana.lib.model.user.UserId
 import com.cramsan.framework.annotations.NetworkModel
 import com.cramsan.framework.annotations.api.ResponseBody
+import kotlinx.datetime.LocalDate
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 /**
  * Network response for a unit occupant record.
- *
- * Date fields (startDate, endDate) are ISO 8601 strings ("YYYY-MM-DD") as returned by PostgREST.
- * Timestamp fields (addedAt) are epoch seconds (Long).
  */
+@OptIn(ExperimentalTime::class)
 @NetworkModel
 @Serializable
 data class OccupantNetworkResponse(
@@ -25,8 +26,8 @@ data class OccupantNetworkResponse(
     @SerialName("added_by") val addedBy: UserId?,
     @SerialName("occupant_type") val occupantType: OccupantType,
     @SerialName("is_primary") val isPrimary: Boolean,
-    @SerialName("start_date") val startDate: String,
-    @SerialName("end_date") val endDate: String?,
+    @SerialName("start_date") val startDate: LocalDate,
+    @SerialName("end_date") val endDate: LocalDate?,
     val status: OccupancyStatus,
-    @SerialName("added_at") val addedAt: Long,
+    @SerialName("added_at") val addedAt: Instant,
 ) : ResponseBody

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/occupant/OccupantNetworkResponse.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/occupant/OccupantNetworkResponse.kt
@@ -24,6 +24,8 @@ data class OccupantNetworkResponse(
     @SerialName("unit_id") val unitId: UnitId,
     @SerialName("user_id") val userId: UserId?,
     @SerialName("added_by") val addedBy: UserId?,
+    val name: String,
+    val email: String?,
     @SerialName("occupant_type") val occupantType: OccupantType,
     @SerialName("is_primary") val isPrimary: Boolean,
     @SerialName("start_date") val startDate: LocalDate,

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/occupant/UpdateOccupantNetworkRequest.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/occupant/UpdateOccupantNetworkRequest.kt
@@ -15,6 +15,8 @@ import kotlinx.serialization.Serializable
 @NetworkModel
 @Serializable
 data class UpdateOccupantNetworkRequest(
+    val name: String?,
+    val email: String?,
     @SerialName("occupant_type") val occupantType: OccupantType?,
     @SerialName("is_primary") val isPrimary: Boolean?,
     @SerialName("end_date") val endDate: String?,

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/occupant/UpdateOccupantNetworkRequest.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/occupant/UpdateOccupantNetworkRequest.kt
@@ -15,8 +15,6 @@ import kotlinx.serialization.Serializable
 @NetworkModel
 @Serializable
 data class UpdateOccupantNetworkRequest(
-    val name: String?,
-    val email: String?,
     @SerialName("occupant_type") val occupantType: OccupantType?,
     @SerialName("is_primary") val isPrimary: Boolean?,
     @SerialName("end_date") val endDate: String?,

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/occupant/UpdateOccupantNetworkRequest.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/occupant/UpdateOccupantNetworkRequest.kt
@@ -4,19 +4,18 @@ import com.cramsan.edifikana.lib.model.occupant.OccupancyStatus
 import com.cramsan.edifikana.lib.model.occupant.OccupantType
 import com.cramsan.framework.annotations.NetworkModel
 import com.cramsan.framework.annotations.api.RequestBody
+import kotlinx.datetime.LocalDate
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
  * Network request to update an existing unit occupant record. Only provided (non-null) fields are updated.
- *
- * Date fields (endDate) are ISO 8601 strings ("YYYY-MM-DD").
  */
 @NetworkModel
 @Serializable
 data class UpdateOccupantNetworkRequest(
     @SerialName("occupant_type") val occupantType: OccupantType?,
     @SerialName("is_primary") val isPrimary: Boolean?,
-    @SerialName("end_date") val endDate: String?,
+    @SerialName("end_date") val endDate: LocalDate?,
     val status: OccupancyStatus?,
 ) : RequestBody

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/occupant/UpdateOccupantNetworkRequest.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/network/occupant/UpdateOccupantNetworkRequest.kt
@@ -14,6 +14,8 @@ import kotlinx.serialization.Serializable
 @NetworkModel
 @Serializable
 data class UpdateOccupantNetworkRequest(
+    val name: String?,
+    val email: String?,
     @SerialName("occupant_type") val occupantType: OccupantType?,
     @SerialName("is_primary") val isPrimary: Boolean?,
     @SerialName("end_date") val endDate: LocalDate?,

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/occupant/OccupantModel.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/occupant/OccupantModel.kt
@@ -1,6 +1,5 @@
 package com.cramsan.edifikana.lib.model.occupant
 
-import com.cramsan.edifikana.lib.model.organization.OrganizationId
 import com.cramsan.edifikana.lib.model.unit.UnitId
 import com.cramsan.edifikana.lib.model.user.UserId
 import kotlinx.datetime.LocalDate
@@ -14,11 +13,8 @@ import kotlinx.datetime.LocalDate
 data class OccupantModel(
     val id: OccupantId,
     val unitId: UnitId,
-    val orgId: OrganizationId,
     val userId: UserId?,
     val addedBy: UserId?,
-    val name: String,
-    val email: String?,
     val occupantType: OccupantType,
     val isPrimary: Boolean,
     val startDate: LocalDate,

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/occupant/OccupantModel.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/occupant/OccupantModel.kt
@@ -15,6 +15,8 @@ data class OccupantModel(
     val unitId: UnitId,
     val userId: UserId?,
     val addedBy: UserId?,
+    val name: String,
+    val email: String?,
     val occupantType: OccupantType,
     val isPrimary: Boolean,
     val startDate: LocalDate,

--- a/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/occupant/OccupantModel.kt
+++ b/edifikana/shared/src/commonMain/kotlin/com/cramsan/edifikana/lib/model/occupant/OccupantModel.kt
@@ -3,13 +3,13 @@ package com.cramsan.edifikana.lib.model.occupant
 import com.cramsan.edifikana.lib.model.unit.UnitId
 import com.cramsan.edifikana.lib.model.user.UserId
 import kotlinx.datetime.LocalDate
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 /**
  * Domain model representing a unit occupancy record.
- *
- * Timestamp fields (addedAt) are epoch seconds (Long).
- * Date fields (startDate, endDate) use [LocalDate] (date-only, no time component).
  */
+@OptIn(ExperimentalTime::class)
 data class OccupantModel(
     val id: OccupantId,
     val unitId: UnitId,
@@ -20,5 +20,5 @@ data class OccupantModel(
     val startDate: LocalDate,
     val endDate: LocalDate?,
     val status: OccupancyStatus,
-    val addedAt: Long,
+    val addedAt: Instant,
 )

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ org.gradle.jvmargs=-Xmx8G
 
 # Enable parallel execution across decoupled modules.
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-org.gradle.parallel=true
+org.gradle.parallel=false
 
 # Cap the number of worker threads for parallel execution.
 org.gradle.workers.max=8


### PR DESCRIPTION
## Summary

Implements the full Occupant API and backend service stack for managing occupants in the Edifikana application. Occupants represent people physically associated with a unit (tenants, owners, or residents) and may be linked to a Supabase Auth user account.

## Changes

### API Layer
- **OccupantApi.kt**: Network interface defining all occupant operations (add, get, list, update, remove)
- **Network Models**:
  - `CreateOccupantNetworkRequest`: Request to add new occupant
  - `OccupantListNetworkResponse`: List response with occupant details
  - `GetOccupantsForUnitQueryParams`: Query parameters for filtering (includeInactive flag)

### Backend Implementation
- **OccupantController.kt**: REST routes registered under authenticated routing
  - `POST /occupants` - Add occupant
  - `GET /occupants/{occupantId}` - Get occupant
  - `GET /units/{unitId}/occupants` - List unit occupants (with includeInactive query param)
  - `PUT /occupants/{occupantId}` - Update occupant
  - `DELETE /occupants/{occupantId}` - Soft remove occupant

- **OccupantService.kt**: Business logic layer with:
  - RBAC enforcement (Admin/Staff full access, Residents can only view their own record)
  - Primary occupant management (automatically unsets primary status on other occupants when setting a new primary)
  - Soft remove logic (sets status=Inactive, prevents removal if primary and other active occupants exist)
  - Unit-scoped RBAC validation

- **OccupantDatastore.kt + SupabaseOccupantDatastore.kt**: Supabase PostgREST layer
  - `insertOccupant()`: Create new occupant
  - `findOccupantById()`: Retrieve by ID
  - `findOccupantsByUnit()`: Query with optional status filtering
  - `clearPrimaryForUnit()`: Unset primary flag on all active occupants for a unit
  - `updateOccupant()`: Update occupant record
  - `softRemoveOccupant()`: Mark as inactive with end date

### Models & Shared Data
- **OccupantEntity.kt**: Database entity with all occupant fields
- **RBACService.kt**: Enhanced with occupant-specific access control
- **OccupantModels.kt** (shared): Value types and enums (OccupantId, OccupantType, OccupantStatus)

### Dependency Injection
- Registered OccupantService and OccupantDatastore as Koin singletons
- Added controller route registration

## Key Business Logic

### Primary Occupant Management
- When adding/updating an occupant with `isPrimary=true`, automatically unsets the primary flag on all other active occupants for that unit
- Prevents removing a primary occupant if other active occupants exist (returns 409 Conflict)
- Ensures each unit always has exactly one primary occupant

### Soft Remove
- `removeOccupant` sets `status=Inactive` and `end_date=today` instead of hard-deleting
- Maintains historical records for audit/reporting purposes

### RBAC
- **Admin/Staff**: Full CRUD access to all occupants in their organization
- **Resident**: Read-only access to their own occupant record (matched by user_id from JWT)
- All write operations (POST, PUT, DELETE) restricted to Admin/Staff

## Testing
- **OccupantServiceTest.kt**: Tests primary occupant logic, soft remove guards, and business rules
- **OccupantControllerTest.kt**: Tests route handling and HTTP response codes
- **SupabaseOccupantDatastoreIntegrationTest.kt**: Integration tests against Supabase
- **RBACServiceTest.kt**: Enhanced with occupant RBAC test cases

## Dependencies
- Requires #382 (unit_occupants table schema)
- Requires #381 (units foundation)
- Requires #394 (RLS policies)

Resolves #419