### PR TITLE
[EDIFIKANA] #362 Idempotent user-org association via upsert + DO NOTHING

### DIFF
--- a/edifikana/back-end/src/integTest/kotlin/com/cramsan/edifikana/server/datastore/supabase/SupabaseMembershipDatastoreIntegrationTest.kt
+++ b/edifikana/back-end/src/integTest/kotlin/com/cramsan/edifikana/server/datastore/supabase/SupabaseMembershipDatastoreIntegrationTest.kt
@@ -544,6 +544,78 @@ class SupabaseMembershipDatastoreIntegrationTest : SupabaseIntegrationTest() {
         assertTrue(result.isSuccess)
     }
 
+    // -------------------------------------------------------------------------
+    // acceptInviteByCode
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `acceptInviteByCode creates ACTIVE membership with role from invite`() = runCoroutineTest {
+        // Arrange
+        val email = "acceptinvite-${testPrefix}@example.com"
+        val userId = createTestUser(email)
+        val inviteId = createTestInvite(
+            email = email,
+            organizationId = orgId!!,
+            expiration = clock.now().plus(kotlin.time.Duration.parse("7d")),
+            role = InviteRole.EMPLOYEE,
+        )
+
+        // Act
+        val result = membershipDatastore.acceptInviteByCode(inviteId, userId)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        val member = membershipDatastore.getMember(orgId!!, userId).getOrThrow()
+        assertNotNull(member)
+        assertEquals(OrgRole.EMPLOYEE, member.role)
+    }
+
+    @Test
+    fun `acceptInviteByCode reactivates previously-inactive member with new role from invite`() = runCoroutineTest {
+        // Arrange
+        val email = "reactivate-${testPrefix}@example.com"
+        val userId = createTestUser(email)
+        organizationDatastore.addUserToOrganization(userId, orgId!!, OrgRole.EMPLOYEE)
+        membershipDatastore.removeMember(orgId!!, userId)
+        val inviteId = createTestInvite(
+            email = email,
+            organizationId = orgId!!,
+            expiration = clock.now().plus(kotlin.time.Duration.parse("7d")),
+            role = InviteRole.ADMIN,
+        )
+
+        // Act
+        val result = membershipDatastore.acceptInviteByCode(inviteId, userId)
+
+        // Assert
+        assertTrue(result.isSuccess)
+        val member = membershipDatastore.getMember(orgId!!, userId).getOrThrow()
+        assertNotNull(member)
+        assertEquals(OrgRole.ADMIN, member.role)
+    }
+
+    @Test
+    fun `acceptInviteByCode second call on same invite fails because invite is already accepted`() = runCoroutineTest {
+        // Arrange
+        val email = "doubleclaim-${testPrefix}@example.com"
+        val userId = createTestUser(email)
+        val inviteId = createTestInvite(
+            email = email,
+            organizationId = orgId!!,
+            expiration = clock.now().plus(kotlin.time.Duration.parse("7d")),
+            role = InviteRole.EMPLOYEE,
+        )
+        val firstResult = membershipDatastore.acceptInviteByCode(inviteId, userId)
+        assertTrue(firstResult.isSuccess)
+
+        // Act
+        val secondResult = membershipDatastore.acceptInviteByCode(inviteId, userId)
+
+        // Assert — acceptedAt is already set; filter returns 0 rows and decodeSingle() throws
+        assertTrue(secondResult.isFailure)
+        assertNotNull(membershipDatastore.getMember(orgId!!, userId).getOrThrow())
+    }
+
     /**
      * Purges all tasks created during the test before the base class tearDown runs.
      * Required because purgeProperty triggers ON DELETE SET NULL on tasks.property_id,

--- a/edifikana/back-end/src/integTest/kotlin/com/cramsan/edifikana/server/datastore/supabase/SupabaseOrganizationDatastoreIntegrationTest.kt
+++ b/edifikana/back-end/src/integTest/kotlin/com/cramsan/edifikana/server/datastore/supabase/SupabaseOrganizationDatastoreIntegrationTest.kt
@@ -10,6 +10,9 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 
 class SupabaseOrganizationDatastoreIntegrationTest : SupabaseIntegrationTest() {
     private lateinit var test_prefix: String
@@ -170,15 +173,50 @@ class SupabaseOrganizationDatastoreIntegrationTest : SupabaseIntegrationTest() {
         val firstAdd = organizationDatastore.addUserToOrganization(newUser, orgId, OrgRole.EMPLOYEE)
         val secondAdd = organizationDatastore.addUserToOrganization(newUser, orgId, OrgRole.EMPLOYEE)
 
-        // Assert
+        // Assert — upsert with ignoreDuplicates=true makes both calls succeed idempotently
         assertTrue(firstAdd.isSuccess)
-        // Depending on DB constraints, secondAdd may succeed or fail gracefully
-        assertTrue(secondAdd.isSuccess || secondAdd.isFailure)
-        val orgsResult = organizationDatastore.getOrganizationsForUser(newUser)
-        assertTrue(orgsResult.isSuccess)
-        val orgs = orgsResult.getOrNull()
-        assertNotNull(orgs)
-        assertTrue(orgs.any { it.id == orgId })
+        assertTrue(secondAdd.isSuccess)
+        val roleResult = organizationDatastore.getUserRole(newUser, orgId)
+        assertTrue(roleResult.isSuccess)
+        assertEquals(OrgRole.EMPLOYEE, roleResult.getOrNull())
+    }
+
+    @Test
+    fun `addUserToOrganization preserves original role when called with a different role`() = runCoroutineTest {
+        // Arrange
+        val orgId = createTestOrganization("test_org_$test_prefix", "")
+        val newUser = createTestUser("rolepreserve-${test_prefix}@example.com")
+
+        // Act
+        val firstAdd = organizationDatastore.addUserToOrganization(newUser, orgId, OrgRole.EMPLOYEE)
+        val secondAdd = organizationDatastore.addUserToOrganization(newUser, orgId, OrgRole.OWNER)
+
+        // Assert — DO NOTHING preserves the original role; a duplicate call cannot escalate privileges
+        assertTrue(firstAdd.isSuccess)
+        assertTrue(secondAdd.isSuccess)
+        val roleResult = organizationDatastore.getUserRole(newUser, orgId)
+        assertTrue(roleResult.isSuccess)
+        assertEquals(OrgRole.EMPLOYEE, roleResult.getOrNull())
+    }
+
+    @Test
+    fun `addUserToOrganization concurrent calls all succeed and produce exactly one membership row`() = runCoroutineTest {
+        // Arrange
+        val orgId = createTestOrganization("test_org_$test_prefix", "")
+        val newUser = createTestUser("concurrent-${test_prefix}@example.com")
+
+        // Act — 5 concurrent upsert requests
+        val results = coroutineScope {
+            (1..5).map {
+                async { organizationDatastore.addUserToOrganization(newUser, orgId, OrgRole.EMPLOYEE) }
+            }.awaitAll()
+        }
+
+        // Assert — all calls succeed; exactly one row with the expected role
+        results.forEach { assertTrue(it.isSuccess) }
+        val roleResult = organizationDatastore.getUserRole(newUser, orgId)
+        assertTrue(roleResult.isSuccess)
+        assertEquals(OrgRole.EMPLOYEE, roleResult.getOrNull())
     }
 
     @Test

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/supabase/SupabaseMembershipDatastore.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/supabase/SupabaseMembershipDatastore.kt
@@ -240,7 +240,8 @@ class SupabaseMembershipDatastore(private val postgrest: Postgrest, private val 
         runSuspendCatching(TAG) {
             logD(TAG, "Accepting invite %s for user %s", inviteId, userId)
 
-            // Mark invite as accepted
+            // LAYER 1: `acceptedAt isExact null` filter serializes concurrent accepts — only one
+            // call wins the update; the second gets 0 rows and decodeSingle() throws.
             val invite =
                 postgrest
                     .from(InviteEntity.COLLECTION)
@@ -256,8 +257,8 @@ class SupabaseMembershipDatastore(private val postgrest: Postgrest, private val 
                     }.decodeSingle<InviteEntity>()
                     .toInvite()
 
-            // Upsert the org membership row; sets status=ACTIVE and joined_at=now()
-            // so a previously-inactive member is reactivated with the new role.
+            // LAYER 2: DO UPDATE reactivates previously-inactive members with the invite's
+            // role. Intentional — re-joining via invite is explicit user action.
             val mapping =
                 UserOrganizationMappingEntity.AcceptInviteEntity(
                     userId = userId.userId,

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/supabase/SupabaseOrganizationDatastore.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/supabase/SupabaseOrganizationDatastore.kt
@@ -159,10 +159,14 @@ class SupabaseOrganizationDatastore(private val postgrest: Postgrest, private va
                     organizationId = organizationId,
                     role = role,
                 )
+            // ON CONFLICT DO NOTHING: idempotent against concurrent inserts; preserves existing
+            // role so a duplicate call cannot downgrade an OWNER via privilege manipulation.
             postgrest
                 .from(UserOrganizationMappingEntity.COLLECTION)
-                .insert(userOrgMapping) { select() }
-                .decodeSingle<UserOrganizationMappingEntity>()
+                .upsert(userOrgMapping) {
+                    onConflict = "user_id, organization_id"
+                    ignoreDuplicates = true
+                }
         }
     }
 

--- a/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/supabase/SupabasePropertyDatastore.kt
+++ b/edifikana/back-end/src/main/kotlin/com/cramsan/edifikana/server/datastore/supabase/SupabasePropertyDatastore.kt
@@ -48,7 +48,8 @@ class SupabasePropertyDatastore(private val postgrest: Postgrest, private val cl
                         select()
                     }.decodeSingle<PropertyEntity>()
 
-            // Now associate this entry with the user that created it
+            // Plain insert is safe: createdProperty.id is a freshly generated UUID, so no
+            // concurrent call can produce the same (userId, propertyId) pair.
             postgrest
                 .from(UserPropertyMappingEntity.COLLECTION)
                 .insert(

--- a/edifikana/back-end/src/test/kotlin/com/cramsan/edifikana/server/service/MembershipServiceTest.kt
+++ b/edifikana/back-end/src/test/kotlin/com/cramsan/edifikana/server/service/MembershipServiceTest.kt
@@ -645,7 +645,8 @@ class MembershipServiceTest {
             val email = "user@example.com"
             val orgId = OrganizationId("org123")
             val inviteId = InviteId("invite123")
-            val invite = Invite(
+            val invite =
+                Invite(
                 id = inviteId,
                 email = email,
                 organizationId = orgId,

--- a/edifikana/back-end/src/test/kotlin/com/cramsan/edifikana/server/service/MembershipServiceTest.kt
+++ b/edifikana/back-end/src/test/kotlin/com/cramsan/edifikana/server/service/MembershipServiceTest.kt
@@ -615,6 +615,60 @@ class MembershipServiceTest {
         }
 
     /**
+     * Tests that joinViaCode fails when the invite code is not found because it was already accepted.
+     */
+    @Test
+    fun `joinViaCode should fail when invite is already accepted and no longer retrievable`() =
+        runTest {
+            // Arrange — getInviteByCode filters acceptedAt=null, so accepted invites return null
+            val callerId = UserId("user123")
+            val inviteCode = "ALREADY_USED"
+            coEvery { membershipDatastore.getInviteByCode(inviteCode) } returns Result.success(null)
+
+            // Act
+            val result = membershipService.joinViaCode(callerId, inviteCode)
+
+            // Assert
+            assertTrue(result.isFailure)
+        }
+
+    /**
+     * Tests that joinViaCode succeeds for a previously-inactive member; the service delegates
+     * reactivation entirely to the datastore and requires no extra logic.
+     */
+    @Test
+    fun `joinViaCode should succeed and propagate datastore success for already-inactive member`() =
+        runTest {
+            // Arrange
+            val callerId = UserId("user123")
+            val inviteCode = "ABC123"
+            val email = "user@example.com"
+            val orgId = OrganizationId("org123")
+            val inviteId = InviteId("invite123")
+            val invite = Invite(
+                id = inviteId,
+                email = email,
+                organizationId = orgId,
+                role = InviteRole.ADMIN,
+                expiration = clock.now() + 14.days,
+                inviteCode = inviteCode,
+            )
+            val user = mockk<User>()
+            every { user.email } returns email
+            coEvery { membershipDatastore.getInviteByCode(inviteCode) } returns Result.success(invite)
+            coEvery { userDatastore.getUser(callerId) } returns Result.success(user)
+            // Datastore handles the inactive→active transition; service just propagates success
+            coEvery { membershipDatastore.acceptInviteByCode(inviteId, callerId) } returns Result.success(Unit)
+
+            // Act
+            val result = membershipService.joinViaCode(callerId, inviteCode)
+
+            // Assert
+            assertTrue(result.isSuccess)
+            coVerify { membershipDatastore.acceptInviteByCode(inviteId, callerId) }
+        }
+
+    /**
      * Tests that joinViaCode fails when the caller's email does not match the invite's email.
      */
     @Test


### PR DESCRIPTION
## Summary

Closes #362

- `addUserToOrganization()` changed from `.insert()` to `.upsert()` with `ignoreDuplicates = true` (ON CONFLICT DO NOTHING), making concurrent calls idempotent and preventing privilege escalation via a duplicate call with a lower-privileged role
- Added comments to `acceptInviteByCode()` documenting its two serialization layers (invite filter + membership upsert) and to `createProperty()` explaining why the plain insert is safe
- No SQL migration needed — `unique_user_organization` constraint already exists from migration `20260124000002`

## Test plan

- [x] Strengthened weak `isSuccess || isFailure` assertion in existing `addUserToOrganization should handle adding same user twice gracefully` integ test
- [x] New integ test: `addUserToOrganization preserves original role when called with a different role` — confirms DO NOTHING prevents privilege escalation
- [x] New integ test: `addUserToOrganization concurrent calls all succeed and produce exactly one membership row`
- [x] New integ tests for `acceptInviteByCode` (previously zero coverage): creates membership, reactivates inactive member, second call fails
- [x] New unit tests in `MembershipServiceTest`: accepted-invite code path, inactive-member pass-through
- [x] All unit tests pass (`./gradlew :edifikana:back-end:test`)
- [x] All integration tests pass
- [x] `releaseAll` passes cleanly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)